### PR TITLE
Translate several roadmap JSON files to Spanish

### DIFF
--- a/public/roadmap-content/ai-agents.json
+++ b/public/roadmap-content/ai-agents.json
@@ -1,199 +1,199 @@
 {
   "VPI89s-m885r2YrXjYxdd": {
-    "title": "Basic Backend Development",
-    "description": "Before you start learning how to build AI agents, we would recommend you to have a basic knowledge of Backend development. This includes, programming language knowledge, interacting with database and basics of APIs at minimum.\n\nVisit the following resources to learn more:",
+    "title": "Desarrollo Backend Básico",
+    "description": "Antes de comenzar a aprender cómo construir agentes de IA, te recomendamos tener un conocimiento básico de desarrollo Backend. Esto incluye, como mínimo, conocimiento de lenguajes de programación, interacción con bases de datos y conceptos básicos de APIs.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "Introduction to the server-side",
+        "title": "Introducción al lado del servidor",
         "url": "https://developer.mozilla.org/en-US/docs/Learn/Server-side/First_steps/Introduction",
         "type": "article"
       },
       {
-        "title": "What is a REST API? - Red Hat",
+        "title": "¿Qué es una API REST? - Red Hat",
         "url": "https://www.redhat.com/en/topics/api/what-is-a-rest-api",
         "type": "article"
       },
       {
-        "title": "What is a Database? - Oracle",
+        "title": "¿Qué es una base de datos? - Oracle",
         "url": "https://www.oracle.com/database/what-is-database/",
         "type": "article"
       }
     ]
   },
   "McREk2zHOlIrqbGSKbX-J": {
-    "title": "Git and Terminal Usage",
-    "description": "Git and the terminal are key tools for AI agents and developers. Git lets you track changes in code, work with branches, and collaborate safely with others. It stores snapshots of your work so you can undo mistakes or merge ideas. The terminal (command line) lets you move around files, run programs, set up servers, and control tools like Git quickly without a GUI.\n\nVisit the following resources to learn more:",
+    "title": "Uso de Git y Terminal",
+    "description": "Git y la terminal son herramientas clave para los agentes de IA y los desarrolladores. Git te permite rastrear cambios en el código, trabajar con ramas y colaborar de forma segura con otros. Almacena instantáneas de tu trabajo para que puedas deshacer errores o fusionar ideas. La terminal (línea de comandos) te permite moverte entre archivos, ejecutar programas, configurar servidores y controlar herramientas como Git rápidamente sin una GUI.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "Git Basics",
+        "title": "Conceptos básicos de Git",
         "url": "https://git-scm.com/doc",
         "type": "article"
       },
       {
-        "title": "Introduction to the Terminal",
+        "title": "Introducción a la Terminal",
         "url": "https://ubuntu.com/tutorials/command-line-for-beginners#1-overview",
         "type": "article"
       },
       {
-        "title": "Git and Terminal Basics Crash Course (YouTube)",
+        "title": "Curso Intensivo de Conceptos Básicos de Git y Terminal (YouTube)",
         "url": "https://www.youtube.com/watch?v=HVsySz-h9r4",
         "type": "video"
       }
     ]
   },
   "QtTwecLdvQa8pgELJ6i80": {
-    "title": "REST API Knowledge",
-    "description": "A **REST API** (Representational State Transfer) is an architectural style for designing networked applications. In AI agents, REST APIs enable communication between the agent and external systems, allowing for data exchange and integration. The agent can use REST APIs to retrieve data from external sources, send data to external systems, and interact with other AI agents or services. This provides a flexible and scalable way to integrate with various systems, enabling the agent to access a wide range of data and services. REST APIs in AI agents support a variety of functions, including data retrieval, data sending, and system interaction. They play a crucial role in facilitating communication between AI agents and external systems, making them a fundamental component of AI agent architecture.\n\nVisit the following resources to learn more:",
+    "title": "Conocimiento de API REST",
+    "description": "Una **API REST** (Transferencia de Estado Representacional) es un estilo arquitectónico para diseñar aplicaciones en red. En los agentes de IA, las API REST permiten la comunicación entre el agente y los sistemas externos, facilitando el intercambio e integración de datos. El agente puede usar API REST para recuperar datos de fuentes externas, enviar datos a sistemas externos e interactuar con otros agentes o servicios de IA. Esto proporciona una forma flexible y escalable de integrarse con diversos sistemas, permitiendo al agente acceder a una amplia gama de datos y servicios. Las API REST en agentes de IA admiten una variedad de funciones, incluyendo la recuperación de datos, el envío de datos y la interacción del sistema. Desempeñan un papel crucial en la facilitación de la comunicación entre los agentes de IA y los sistemas externos, convirtiéndolos en un componente fundamental de la arquitectura de agentes de IA.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "What is RESTful API? - RESTful API Explained - AWS",
+        "title": "¿Qué es una API RESTful? - API RESTful Explicada - AWS",
         "url": "https://aws.amazon.com/what-is/restful-api/",
         "type": "article"
       },
       {
-        "title": "What Is a REST API? Examples, Uses & Challenges ",
+        "title": "¿Qué es una API REST? Ejemplos, Usos y Desafíos",
         "url": "https://blog.postman.com/rest-api-examples/",
         "type": "article"
       }
     ]
   },
   "ZF5_5Y5zqa75Ov22JACX6": {
-    "title": "Transformer Models and LLMs",
-    "description": "Transformer models are a type of neural network that read input data—like words in a sentence—all at once instead of one piece at a time. They use “attention” to find which parts of the input matter most for each other part. This lets them learn patterns in language very well. When a transformer has been trained on a very large set of text, we call it a Large Language Model (LLM). An LLM can answer questions, write text, translate languages, and code because it has seen many examples during training. AI agents use these models as their “brains.” They feed tasks or prompts to the LLM, get back text or plans, and then act on those results. This structure helps agents understand goals, break them into steps, and adjust based on feedback, making them useful for chatbots, research helpers, and automation tools.\n\nVisit the following resources to learn more:",
+    "title": "Modelos Transformer y LLMs",
+    "description": "Los modelos Transformer son un tipo de red neuronal que lee datos de entrada—como palabras en una oración—todos a la vez en lugar de una pieza a la vez. Usan “atención” para encontrar qué partes de la entrada son más importantes para cada otra parte. Esto les permite aprender patrones en el lenguaje muy bien. Cuando un transformer ha sido entrenado con un conjunto muy grande de texto, lo llamamos un Modelo de Lenguaje Grande (LLM). Un LLM puede responder preguntas, escribir texto, traducir idiomas y programar porque ha visto muchos ejemplos durante el entrenamiento. Los agentes de IA usan estos modelos como sus “cerebros”. Alimentan tareas o indicaciones al LLM, obtienen texto o planes de vuelta, y luego actúan sobre esos resultados. Esta estructura ayuda a los agentes a comprender objetivos, dividirlos en pasos y ajustarse según la retroalimentación, haciéndolos útiles para chatbots, ayudantes de investigación y herramientas de automatización.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "Exploring Open Source AI Models: LLMs and Transformer Architectures",
+        "title": "Explorando Modelos de IA de Código Abierto: LLMs y Arquitecturas Transformer",
         "url": "https://llmmodels.org/blog/exploring-open-source-ai-models-llms-and-transformer-architectures/",
         "type": "article"
       },
       {
-        "title": "Transformer Models Vs Llm Comparison",
+        "title": "Comparación entre Modelos Transformer y LLM",
         "url": "https://www.restack.io/p/transformer-models-answer-vs-llm-cat-ai",
         "type": "article"
       },
       {
-        "title": "How Transformer LLMs Work",
+        "title": "Cómo Funcionan los LLMs Transformer",
         "url": "https://www.deeplearning.ai/short-courses/how-transformer-llms-work/",
         "type": "article"
       }
     ]
   },
   "GAjuWyJl9CI1nqXBp6XCf": {
-    "title": "Tokenization",
-    "description": "Tokenization is the step where raw text is broken into small pieces called tokens, and each token is given a unique number. A token can be a whole word, part of a word, a punctuation mark, or even a space. The list of all possible tokens is the model’s vocabulary. Once text is turned into these numbered tokens, the model can look up an embedding for each number and start its math. By working with tokens instead of full sentences, the model keeps the input size steady and can handle new or rare words by slicing them into familiar sub-pieces. After the model finishes its work, the numbered tokens are turned back into text through the same vocabulary map, letting the user read the result.\n\nVisit the following resources to learn more:",
+    "title": "Tokenización",
+    "description": "La tokenización es el paso donde el texto crudo se divide en pequeñas piezas llamadas tokens, y a cada token se le asigna un número único. Un token puede ser una palabra completa, parte de una palabra, un signo de puntuación o incluso un espacio. La lista de todos los tokens posibles es el vocabulario del modelo. Una vez que el texto se convierte en estos tokens numerados, el modelo puede buscar una incrustación para cada número y comenzar sus cálculos. Al trabajar con tokens en lugar de oraciones completas, el modelo mantiene el tamaño de entrada estable y puede manejar palabras nuevas o raras dividiéndolas en sub-piezas familiares. Después de que el modelo termina su trabajo, los tokens numerados se convierten de nuevo en texto a través del mismo mapa de vocabulario, permitiendo al usuario leer el resultado.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "Explaining Tokens — the Language and Currency of AI",
+        "title": "Explicando los Tokens — el Lenguaje y la Moneda de la IA",
         "url": "https://blogs.nvidia.com/blog/ai-tokens-explained/",
         "type": "article"
       },
       {
-        "title": "What is Tokenization? Types, Use Cases, Implementation",
+        "title": "¿Qué es la Tokenización? Tipos, Casos de Uso, Implementación",
         "url": "https://www.datacamp.com/blog/what-is-tokenization",
         "type": "article"
       }
     ]
   },
   "dyn1LSioema-Bf9lLTgUZ": {
-    "title": "Context Windows",
-    "description": "A context window is the chunk of text a large language model can read at one time. It is measured in tokens, which are pieces of words. If a model has a 4,000-token window, it can only “look at” up to about 3,000 words before it must forget or shorten earlier parts. New tokens push old ones out, like a sliding window moving over text. The window size sets hard limits on how long a prompt, chat history, or document can be. A small window forces you to keep inputs short or split them, while a large window lets the model follow longer stories and hold more facts. Choosing the right window size balances cost, speed, and how much detail the model can keep in mind at once.\n\nNew techniques, like retrieval-augmented generation (RAG) and long-context transformers (e.g., Claude 3, Gemini 1.5), aim to extend usable context without hitting model limits directly.\n\nVisit the following resources to learn more:",
+    "title": "Ventanas de Contexto",
+    "description": "Una ventana de contexto es el fragmento de texto que un modelo de lenguaje grande puede leer de una vez. Se mide en tokens, que son piezas de palabras. Si un modelo tiene una ventana de 4,000 tokens, solo puede “ver” hasta unas 3,000 palabras antes de que deba olvidar o acortar partes anteriores. Los nuevos tokens empujan a los antiguos, como una ventana deslizante que se mueve sobre el texto. El tamaño de la ventana establece límites estrictos sobre cuán largo puede ser un prompt, historial de chat o documento. Una ventana pequeña te obliga a mantener las entradas cortas o dividirlas, mientras que una ventana grande permite que el modelo siga historias más largas y retenga más hechos. Elegir el tamaño de ventana correcto equilibra el costo, la velocidad y la cantidad de detalles que el modelo puede tener en cuenta a la vez.\n\nNuevas técnicas, como la generación aumentada por recuperación (RAG) y los transformers de contexto largo (por ejemplo, Claude 3, Gemini 1.5), tienen como objetivo extender el contexto utilizable sin alcanzar directamente los límites del modelo.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "What is a Context Window in AI?",
+        "title": "¿Qué es una Ventana de Contexto en IA?",
         "url": "https://www.ibm.com/think/topics/context-window",
         "type": "article"
       },
       {
-        "title": "Scaling Language Models with Retrieval-Augmented Generation (RAG)",
+        "title": "Escalando Modelos de Lenguaje con Generación Aumentada por Recuperación (RAG)",
         "url": "https://arxiv.org/abs/2005.11401",
         "type": "article"
       },
       {
-        "title": "Long Context in Language Models - Anthropic's Claude 3",
+        "title": "Contexto Largo en Modelos de Lenguaje - Claude 3 de Anthropic",
         "url": "https://www.anthropic.com/news/claude-3-family",
         "type": "article"
       }
     ]
   },
   "1fiWPBV99E2YncqdCgUw2": {
-    "title": "Token Based Pricing",
-    "description": "Token-based pricing is how many language-model services charge for use. A token is a small chunk of text, roughly four characters or part of a word. The service counts every token that goes into the model (your prompt) and every token that comes out (the reply). It then multiplies this total by a listed price per thousand tokens. Some plans set one price for input tokens and a higher or lower price for output tokens. Because the bill grows with each token, users often shorten prompts, trim extra words, or cap response length to spend less.\n\nVisit the following resources to learn more:",
+    "title": "Precios Basados en Tokens",
+    "description": "El precio basado в tokens es cómo muchos servicios de modelos de lenguaje cobran por el uso. Un token es un pequeño fragmento de texto, aproximadamente cuatro caracteres o parte de una palabra. El servicio cuenta cada token que entra en el modelo (tu prompt) y cada token que sale (la respuesta). Luego multiplica este total por un precio listado por cada mil tokens. Algunos planes establecen un precio para los tokens de entrada y un precio mayor o menor para los tokens de salida. Debido a que la factura crece con cada token, los usuarios a menudo acortan los prompts, eliminan palabras adicionales o limitan la longitud de la respuesta para gastar menos.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "Explaining Tokens — the Language and Currency of AI",
+        "title": "Explicando los Tokens — el Lenguaje y la Moneda de la IA",
         "url": "https://blogs.nvidia.com/blog/ai-tokens-explained/",
         "type": "article"
       },
       {
-        "title": "What Are AI Tokens?",
+        "title": "¿Qué Son los Tokens de IA?",
         "url": "https://methodshop.com/what-are-ai-tokens/",
         "type": "article"
       },
       {
-        "title": "Pricing - OpenAI",
+        "title": "Precios - OpenAI",
         "url": "https://openai.com/api/pricing/",
         "type": "article"
       }
     ]
   },
   "L1zL1GzqjSAjF06pIIXhy": {
-    "title": "Temperature",
-    "description": "Temperature is a setting that changes how random or predictable an AI model’s text output is. The value usually goes from 0 to 1, sometimes higher. A low temperature, close to 0, makes the model pick the most likely next word almost every time, so the answer is steady and safe but can feel dull or repetitive. A high temperature, like 0.9 or 1.0, lets the model explore less-likely word choices, which can give fresh and creative replies, but it may also add mistakes or drift off topic. By adjusting temperature, you balance reliability and creativity to fit the goal of your task.\n\nVisit the following resources to learn more:",
+    "title": "Temperatura",
+    "description": "La temperatura es un ajuste que cambia cuán aleatoria o predecible es la salida de texto de un modelo de IA. El valor generalmente va de 0 a 1, a veces más alto. Una temperatura baja, cercana a 0, hace que el modelo elija la siguiente palabra más probable casi siempre, por lo que la respuesta es estable y segura, pero puede parecer aburrida o repetitiva. Una temperatura alta, como 0.9 o 1.0, permite al modelo explorar opciones de palabras menos probables, lo que puede dar respuestas frescas y creativas, pero también puede agregar errores o desviarse del tema. Al ajustar la temperatura, equilibras la confiabilidad y la creatividad para adaptarlas al objetivo de tu tarea.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "What Temperature Means in Natural Language Processing and AI",
+        "title": "Qué Significa la Temperatura en el Procesamiento del Lenguaje Natural y la IA",
         "url": "https://thenewstack.io/what-temperature-means-in-natural-language-processing-and-ai/",
         "type": "article"
       },
       {
-        "title": "LLM Temperature: How It Works and When You Should Use It",
+        "title": "Temperatura LLM: Cómo Funciona y Cuándo Deberías Usarla",
         "url": "https://www.vellum.ai/llm-parameters/temperature",
         "type": "article"
       },
       {
-        "title": "What is LLM Temperature? - IBM",
+        "title": "¿Qué es la Temperatura LLM? - IBM",
         "url": "https://www.ibm.com/think/topics/llm-temperature",
         "type": "article"
       },
       {
-        "title": "How Temperature Settings Transform Your AI Agent's Responses",
+        "title": "Cómo los Ajustes de Temperatura Transforman las Respuestas de tu Agente de IA",
         "url": "https://docsbot.ai/article/how-temperature-settings-transform-your-ai-agents-responses",
         "type": "article"
       }
     ]
   },
   "z_N-Y0zGkv8_qHPuVtimL": {
-    "title": "Frequency Penalty",
-    "description": "Frequency penalty is a setting that tells a language model, “Stop repeating yourself.” As the model writes, it keeps track of how many times it has already used each word. A positive frequency-penalty value lowers the chance of picking a word again if it has been seen many times in the current reply. This helps cut down on loops like “very very very” or long blocks that echo the same phrase. A value of 0 turns the rule off, while higher numbers make the model avoid repeats more strongly. If the penalty is too high, the text may miss common words that are still needed, so you often start low (for example 0.2) and adjust. Frequency penalty works together with other controls such as temperature and top-p to shape output that is clear, varied, and not boring.\n\nVisit the following resources to learn more:",
+    "title": "Penalización de Frecuencia",
+    "description": "La penalización de frecuencia es un ajuste que le dice a un modelo de lenguaje: “Deja de repetirte”. A medida que el modelo escribe, realiza un seguimiento de cuántas veces ya ha usado cada palabra. Un valor positivo de penalización de frecuencia reduce la posibilidad de elegir una palabra nuevamente si se ha visto muchas veces en la respuesta actual. Esto ayuda a reducir bucles como “muy muy muy” o bloques largos que repiten la misma frase. Un valor de 0 desactiva la regla, mientras que números más altos hacen que el modelo evite las repeticiones con más fuerza. Si la penalización es demasiado alta, el texto puede omitir palabras comunes que aún son necesarias, por lo que a menudo se comienza bajo (por ejemplo, 0.2) y se ajusta. La penalización de frecuencia funciona junto con otros controles como la temperatura y top-p para dar forma a una salida que sea clara, variada y no aburrida.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "Frequency Penalty Explanation",
+        "title": "Explicación de la Penalización de Frecuencia",
         "url": "https://docs.aipower.org/docs/ai-engine/openai/frequency-penalty",
         "type": "article"
       },
       {
-        "title": "Understanding Frequency Penalty and Presence Penalty",
+        "title": "Entendiendo la Penalización de Frecuencia y la Penalización de Presencia",
         "url": "https://medium.com/@the_tori_report/understanding-frequency-penalty-and-presence-penalty-how-to-fine-tune-ai-generated-text-e5e4f5e779cd",
         "type": "article"
       }
     ]
   },
   "Vd8ycw8pW-ZKvg5WYFtoh": {
-    "title": "Presence Penalty",
-    "description": "Presence penalty is a setting you can adjust when you ask a large language model to write. It pushes the model to choose words it has not used yet. Each time a word has already appeared, the model gets a small score cut for picking it again. A higher penalty gives bigger cuts, so the model looks for new words and fresh ideas. A lower penalty lets the model reuse words more often, which can help with repeats like rhymes or bullet lists. Tuning this control helps you steer the output toward either more variety or more consistency.\n\nVisit the following resources to learn more:",
+    "title": "Penalización de Presencia",
+    "description": "La penalización de presencia es un ajuste que puedes modificar cuando le pides a un modelo de lenguaje grande que escriba. Empuja al modelo a elegir palabras que aún no ha usado. Cada vez que una palabra ya ha aparecido, el modelo recibe un pequeño recorte de puntuación por elegirla de nuevo. Una penalización más alta da recortes más grandes, por lo que el modelo busca nuevas palabras e ideas frescas. Una penalización más baja permite que el modelo reutilice palabras más a menudo, lo que puede ayudar con repeticiones como rimas o listas con viñetas. Ajustar este control te ayuda a dirigir la salida hacia una mayor variedad o una mayor consistencia.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "Understanding Presence Penalty and Frequency Penalty",
+        "title": "Entendiendo la Penalización de Presencia y la Penalización de Frecuencia",
         "url": "https://medium.com/@pushparajgenai2025/understanding-presence-penalty-and-frequency-penalty-in-openai-chat-completion-api-calls-2e3a22547b48",
         "type": "article"
       },
       {
-        "title": "Difference between Frequency and Presence Penalties?",
+        "title": "¿Diferencia entre Penalizaciones de Frecuencia y Presencia?",
         "url": "https://community.openai.com/t/difference-between-frequency-and-presence-penalties/2777",
         "type": "article"
       },
       {
-        "title": "LLM Parameters Explained: A Practical Guide with Examples",
+        "title": "Parámetros LLM Explicados: Una Guía Práctica con Ejemplos",
         "url": "https://learnprompting.org/blog/llm-parameters",
         "type": "article"
       }
@@ -201,44 +201,44 @@
   },
   "icbp1NjurQfdM0dHnz6v2": {
     "title": "Top-p",
-    "description": "Top-p, also called nucleus sampling, is a setting that guides how an LLM picks its next word. The model lists many possible words and sorts them by probability. It then finds the smallest group of top words whose combined chance adds up to the chosen p value, such as 0.9. Only words inside this group stay in the running; the rest are dropped. The model picks one word from the kept group at random, weighted by their original chances. A lower p keeps only the very likely words, so output is safer and more focused. A higher p lets in less likely words, adding surprise and creativity but also more risk of error.\n\nVisit the following resources to learn more:",
+    "description": "Top-p, también llamado muestreo de núcleo, es un ajuste que guía cómo un LLM elige su siguiente palabra. El modelo lista muchas palabras posibles y las ordena por probabilidad. Luego encuentra el grupo más pequeño de palabras principales cuya probabilidad combinada suma el valor p elegido, como 0.9. Solo las palabras dentro de este grupo permanecen en la carrera; el resto se descartan. El modelo elige una palabra del grupo conservado al azar, ponderada por sus probabilidades originales. Un p más bajo mantiene solo las palabras muy probables, por lo que la salida es más segura y enfocada. Un p más alto permite palabras menos probables, agregando sorpresa y creatividad pero también más riesgo de error.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "Nucleus Sampling",
+        "title": "Muestreo de Núcleo",
         "url": "https://nn.labml.ai/sampling/nucleus.html",
         "type": "article"
       },
       {
-        "title": "Sampling Techniques in Large Language Models (LLMs)",
+        "title": "Técnicas de Muestreo en Modelos de Lenguaje Grandes (LLMs)",
         "url": "https://medium.com/@shashankag14/understanding-sampling-techniques-in-large-language-models-llms-dfc28b93f518",
         "type": "article"
       },
       {
-        "title": "Temperature, top_p and top_k for chatbot responses",
+        "title": "Temperatura, top_p y top_k para respuestas de chatbot",
         "url": "https://community.openai.com/t/temperature-top-p-and-top-k-for-chatbot-responses/295542",
         "type": "article"
       }
     ]
   },
   "K0G-Lw069jXUJwZqHtybd": {
-    "title": "Stopping Criteria",
-    "description": "Stopping criteria tell the language model when to stop writing more text. Without them, the model could keep adding words forever, waste time, or spill past the point we care about. Common rules include a maximum number of tokens, a special end-of-sequence token, or a custom string such as `“\\n\\n”`. We can also stop when the answer starts to repeat or reaches a score that means it is off topic. Good stopping rules save cost, speed up replies, and avoid nonsense or unsafe content.\n\nVisit the following resources to learn more:",
+    "title": "Criterios de Detención",
+    "description": "Los criterios de detención le indican al modelo de lenguaje cuándo dejar de escribir más texto. Sin ellos, el modelo podría seguir agregando palabras indefinidamente, perder tiempo o exceder el punto que nos interesa. Las reglas comunes incluyen un número máximo de tokens, un token especial de fin de secuencia o una cadena personalizada como `“\\n\\n”`. También podemos detenernos cuando la respuesta comienza a repetirse o alcanza una puntuación que significa que está fuera de tema. Buenas reglas de detención ahorran costos, aceleran las respuestas y evitan contenido sin sentido o inseguro.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "Defining Stopping Criteria in Large Language Models",
+        "title": "Definición de Criterios de Detención en Modelos de Lenguaje Grandes",
         "url": "https://www.metriccoders.com/post/defining-stopping-criteria-in-large-language-models-a-practical-guide",
         "type": "article"
       },
       {
-        "title": "Stopping Criteria for Decision Tree Algorithm and Tree Plots",
+        "title": "Criterios de Detención para el Algoritmo de Árbol de Decisión y Gráficos de Árbol",
         "url": "https://aieagle.in/stopping-criteria-for-decision-tree-algorithm-and-tree-plots/",
         "type": "article"
       }
     ]
   },
   "DSJAhQhc1dQmBHQ8ZkTau": {
-    "title": "Open Weight Models",
-    "description": "Open-weight models are neural networks whose trained parameters, also called weights, are shared with everyone. Anyone can download the files, run the model, fine-tune it, or build tools on top of it. The licence that comes with the model spells out what you are allowed to do. Some licences are very permissive and even let you use the model for commercial work. Others allow only research or personal projects. Because the weights are public, the community can inspect how the model works, check for bias, and suggest fixes. Open weights also lower costs, since teams do not have to train a large model from scratch. Well-known examples include BLOOM, Falcon, and Llama 2.\n\nVisit the following resources to learn more:",
+    "title": "Modelos de Pesos Abiertos",
+    "description": "Los modelos de pesos abiertos son redes neuronales cuyos parámetros entrenados, también llamados pesos, se comparten con todos. Cualquiera puede descargar los archivos, ejecutar el modelo, ajustarlo o construir herramientas sobre él. La licencia que viene con el modelo detalla lo que se te permite hacer. Algunas licencias son muy permisivas e incluso te permiten usar el modelo para trabajos comerciales. Otras solo permiten proyectos de investigación o personales. Debido a que los pesos son públicos, la comunidad puede inspeccionar cómo funciona el modelo, verificar sesgos y sugerir correcciones. Los pesos abiertos también reducen los costos, ya que los equipos no tienen que entrenar un modelo grande desde cero. Ejemplos conocidos incluyen BLOOM, Falcon y Llama 2.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
         "title": "BLOOM BigScience",
@@ -246,43 +246,43 @@
         "type": "article"
       },
       {
-        "title": "Falcon LLM – Technology Innovation Institute (TII)",
+        "title": "Falcon LLM – Instituto de Innovación Tecnológica (TII)",
         "url": "https://falconllm.tii.ae/",
         "type": "article"
       },
       {
-        "title": "Llama 2 – Meta's Official Announcement",
+        "title": "Llama 2 – Anuncio Oficial de Meta",
         "url": "https://ai.meta.com/llama/",
         "type": "article"
       },
       {
-        "title": "Hugging Face – Open LLM Leaderboard (Top Open Models)",
+        "title": "Hugging Face – Tabla de Clasificación de LLM Abiertos (Mejores Modelos Abiertos)",
         "url": "https://huggingface.co/spaces/HuggingFaceH4/open_llm_leaderboard",
         "type": "article"
       },
       {
-        "title": "EleutherAI – Open Research Collective (GPT-Neo, GPT-J, etc.)",
+        "title": "EleutherAI – Colectivo de Investigación Abierta (GPT-Neo, GPT-J, etc.)",
         "url": "https://www.eleuther.ai/",
         "type": "article"
       }
     ]
   },
   "tJYmEDDwK0LtEux-kwp9B": {
-    "title": "Closed Weight Models",
-    "description": "Closed-weight models are AI systems whose trained parameters—the numbers that hold what the model has learned—are not shared with the public. You can send prompts to these models through an online service or a software kit, but you cannot download the weights, inspect them, or fine-tune them on your own computer. The company that owns the model keeps control and sets the rules for use, often through paid APIs or tight licences. This approach helps the owner protect trade secrets, reduce misuse, and keep a steady income stream. The downside is less freedom for users, higher costs over time, and limited ability to audit or adapt the model. Well-known examples include GPT-4, Claude, and Gemini.\n\nVisit the following resources to learn more:",
+    "title": "Modelos de Pesos Cerrados",
+    "description": "Los modelos de pesos cerrados son sistemas de IA cuyos parámetros entrenados —los números que contienen lo que el modelo ha aprendido— no se comparten con el público. Puedes enviar prompts a estos modelos a través de un servicio en línea o un kit de software, pero no puedes descargar los pesos, inspeccionarlos o ajustarlos en tu propia computadora. La compañía propietaria del modelo mantiene el control y establece las reglas de uso, a menudo a través de API de pago o licencias estrictas. Este enfoque ayuda al propietario a proteger secretos comerciales, reducir el uso indebido y mantener un flujo de ingresos constante. La desventaja es menos libertad para los usuarios, costos más altos con el tiempo y capacidad limitada para auditar o adaptar el modelo. Ejemplos conocidos incluyen GPT-4, Claude y Gemini.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "Open-Source LLMs vs Closed LLMs",
+        "title": "LLMs de Código Abierto vs LLMs Cerrados",
         "url": "https://hatchworks.com/blog/gen-ai/open-source-vs-closed-llms-guide/",
         "type": "article"
       },
       {
-        "title": "2024 Comparison of Open-Source Vs Closed-Source LLMs",
+        "title": "Comparación 2024 de LLMs de Código Abierto Vs Código Cerrado",
         "url": "https://blog.spheron.network/choosing-the-right-llm-2024-comparison-of-open-source-vs-closed-source-llms",
         "type": "article"
       },
       {
-        "title": "Open AI's GPT-4",
+        "title": "GPT-4 de Open AI",
         "url": "https://openai.com/gpt-4",
         "type": "article"
       },
@@ -299,265 +299,265 @@
     ]
   },
   "i2NE6haX9-7mdoV5LQ3Ah": {
-    "title": "Streamed vs Unstreamed Responses",
-    "description": "Streamed and unstreamed responses describe how an AI agent sends its answer to the user. With a streamed response, the agent starts sending words as soon as it generates them. The user sees the text grow on the screen in real time. This feels fast and lets the user stop or change the request early. It is useful for long answers and chat-like apps.\n\nAn unstreamed response waits until the whole answer is ready, then sends it all at once. This makes the code on the client side simpler and is easier to cache or log, but the user must wait longer, especially for big outputs. Choosing between the two depends on the need for speed, the length of the answer, and how complex you want the client and server to be.\n\nVisit the following resources to learn more:",
+    "title": "Respuestas Transmitidas vs No Transmitidas",
+    "description": "Las respuestas transmitidas y no transmitidas describen cómo un agente de IA envía su respuesta al usuario. Con una respuesta transmitida, el agente comienza a enviar palabras tan pronto como las genera. El usuario ve crecer el texto en la pantalla en tiempo real. Esto se siente rápido y permite al usuario detener o cambiar la solicitud temprano. Es útil para respuestas largas y aplicaciones tipo chat.\n\nUna respuesta no transmitida espera hasta que toda la respuesta esté lista, luego la envía toda de una vez. Esto simplifica el código del lado del cliente y es más fácil de almacenar en caché o registrar, pero el usuario debe esperar más, especialmente para salidas grandes. Elegir entre los dos depende de la necesidad de velocidad, la longitud de la respuesta y cuán complejo quieres que sean el cliente y el servidor.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "Streaming Responses in AI: How AI Outputs Are Generated in Real Time",
+        "title": "Respuestas Transmitidas en IA: Cómo se Generan las Salidas de IA en Tiempo Real",
         "url": "https://dev.to/pranshu_kabra_fe98a73547a/streaming-responses-in-ai-how-ai-outputs-are-generated-in-real-time-18kb",
         "type": "article"
       },
       {
-        "title": "AI for Web Devs: Faster Responses with HTTP Streaming",
+        "title": "IA para Desarrolladores Web: Respuestas Más Rápidas con Transmisión HTTP",
         "url": "https://austingil.com/ai-for-web-devs-streaming/",
         "type": "article"
       },
       {
-        "title": "Master the OpenAI API: Stream Responses",
+        "title": "Domina la API de OpenAI: Respuestas Transmitidas",
         "url": "https://www.toolify.ai/gpts/master-the-openai-api-stream-responses-139447",
         "type": "article"
       }
     ]
   },
   "N3yZfUxphxjiupqGpyaS9": {
-    "title": "Reasoning vs Standard Models",
-    "description": "Reasoning models break a task into clear steps and follow a line of logic, while standard models give an answer in one quick move. A reasoning model might write down short notes, check each note, and then combine them to reach the final reply. This helps it solve math problems, plan actions, and spot errors that simple pattern matching would miss. A standard model depends on patterns it learned during training and often guesses the most likely next word. That works well for everyday chat, summaries, or common facts, but it can fail on tricky puzzles or tasks with many linked parts. Reasoning takes more time and computer power, yet it brings higher accuracy and makes the agent easier to debug because you can see its thought steps. Many new AI agents mix both styles: they use quick pattern recall for simple parts and switch to step-by-step reasoning when a goal needs deeper thought.\n\nVisit the following resources to learn more:",
+    "title": "Modelos de Razonamiento vs Estándar",
+    "description": "Los modelos de razonamiento dividen una tarea en pasos claros y siguen una línea de lógica, mientras que los modelos estándar dan una respuesta en un movimiento rápido. Un modelo de razonamiento podría escribir notas cortas, verificar cada nota y luego combinarlas para llegar a la respuesta final. Esto le ayuda a resolver problemas matemáticos, planificar acciones y detectar errores que la simple coincidencia de patrones pasaría por alto. Un modelo estándar depende de los patrones que aprendió durante el entrenamiento y, a menudo, adivina la siguiente palabra más probable. Eso funciona bien para chats cotidianos, resúmenes o hechos comunes, pero puede fallar en acertijos difíciles o tareas con muchas partes vinculadas. El razonamiento lleva más tiempo y potencia informática, pero brinda mayor precisión y hace que el agente sea más fácil de depurar porque puedes ver sus pasos de pensamiento. Muchos agentes de IA nuevos mezclan ambos estilos: usan el recuerdo rápido de patrones para partes simples y cambian al razonamiento paso a paso cuando un objetivo necesita una reflexión más profunda.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "ReAct: Synergizing Reasoning and Acting in Language Models",
+        "title": "ReAct: Sinergizando Razonamiento y Actuación en Modelos de Lenguaje",
         "url": "https://react-lm.github.io/",
         "type": "article"
       },
       {
-        "title": "ReAct Systems: Enhancing LLMs with Reasoning and Action",
+        "title": "Sistemas ReAct: Mejorando LLMs con Razonamiento y Acción",
         "url": "https://learnprompting.org/docs/agents/react",
         "type": "article"
       }
     ]
   },
   "5OW_6o286mj470ElFyJ_5": {
-    "title": "Fine-tuning vs Prompt Engineering",
-    "description": "Fine-tuning and prompt engineering are two ways to get better outputs from a language model. Fine-tuning means training an existing model further with your own examples so it adapts to specific tasks. It needs extra data, computing power, and time but creates deeply specialized models. Prompt engineering, in contrast, leaves the model unchanged and focuses on crafting better instructions or examples in the prompt itself. It is faster, cheaper, and safer when no custom data is available. Fine-tuning suits deep domain needs; prompt engineering fits quick control and prototyping.\n\nVisit the following resources to learn more:",
+    "title": "Ajuste Fino vs Ingeniería de Prompts",
+    "description": "El ajuste fino y la ingeniería de prompts son dos formas de obtener mejores resultados de un modelo de lenguaje. El ajuste fino significa entrenar un modelo existente aún más con tus propios ejemplos para que se adapte a tareas específicas. Necesita datos adicionales, potencia informática y tiempo, pero crea modelos profundamente especializados. La ingeniería de prompts, por el contrario, deja el modelo sin cambios y se enfoca en elaborar mejores instrucciones o ejemplos en el propio prompt. Es más rápido, más barato y más seguro cuando no hay datos personalizados disponibles. El ajuste fino se adapta a las necesidades profundas del dominio; la ingeniería de prompts se ajusta al control rápido y la creación de prototipos.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "OpenAI Fine Tuning",
+        "title": "Ajuste Fino de OpenAI",
         "url": "https://platform.openai.com/docs/guides/fine-tuning",
         "type": "article"
       },
       {
-        "title": "Prompt Engineering Guide",
+        "title": "Guía de Ingeniería de Prompts",
         "url": "https://www.promptingguide.ai/",
         "type": "article"
       },
       {
-        "title": "Prompt Engineering vs Prompt Tuning: A Detailed Explanation",
+        "title": "Ingeniería de Prompts vs Ajuste de Prompts: Una Explicación Detallada",
         "url": "https://medium.com/@aabhi02/prompt-engineering-vs-prompt-tuning-a-detailed-explanation-19ea8ce62ac4",
         "type": "article"
       }
     ]
   },
   "UIm54UmICKgep6s8Itcyv": {
-    "title": "Embeddings and Vector Search",
-    "description": "Embeddings turn words, pictures, or other data into lists of numbers called vectors. Each vector keeps the meaning of the original item. Things with similar meaning get vectors that sit close together in this number space. Vector search scans a large set of vectors and finds the ones nearest to a query vector, even if the exact words differ. This lets AI agents match questions with answers, suggest related items, and link ideas quickly.\n\nVisit the following resources to learn more:",
+    "title": "Embeddings y Búsqueda Vectorial",
+    "description": "Los embeddings convierten palabras, imágenes u otros datos en listas de números llamados vectores. Cada vector conserva el significado del elemento original. Las cosas con significado similar obtienen vectores que se encuentran cerca en este espacio numérico. La búsqueda vectorial escanea un gran conjunto de vectores y encuentra los más cercanos a un vector de consulta, incluso si las palabras exactas difieren. Esto permite a los agentes de IA relacionar preguntas con respuestas, sugerir elementos relacionados y vincular ideas rápidamente.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "OpenAI Embeddings API Documentation",
+        "title": "Documentación de la API de Embeddings de OpenAI",
         "url": "https://platform.openai.com/docs/guides/embeddings/what-are-embeddings",
         "type": "article"
       },
       {
-        "title": "Understanding Embeddings and Vector Search (Pinecone Blog)",
+        "title": "Entendiendo los Embeddings y la Búsqueda Vectorial (Blog de Pinecone)",
         "url": "https://www.pinecone.io/learn/vector-embeddings/",
         "type": "article"
       }
     ]
   },
   "qwVQOwBTLA2yUgRISzC8k": {
-    "title": "Understand the Basics of RAG",
-    "description": "RAG, short for Retrieval-Augmented Generation, is a way to make language models give better answers by letting them look things up before they reply. First, the system turns the user’s question into a search query and scans a knowledge source, such as a set of documents or a database. It then pulls back the most relevant passages, called “retrievals.” Next, the language model reads those passages and uses them, plus its own trained knowledge, to write the final answer. This mix of search and generation helps the model stay up to date, reduce guesswork, and cite real facts. Because it adds outside information on demand, RAG often needs less fine-tuning and can handle topics the base model never saw during training.\n\nVisit the following resources to learn more:",
+    "title": "Comprender los Conceptos Básicos de RAG",
+    "description": "RAG, abreviatura de Generación Aumentada por Recuperación, es una forma de hacer que los modelos de lenguaje den mejores respuestas permitiéndoles buscar información antes de responder. Primero, el sistema convierte la pregunta del usuario en una consulta de búsqueda y escanea una fuente de conocimiento, como un conjunto de documentos o una base de datos. Luego recupera los pasajes más relevantes, llamados “recuperaciones”. A continuación, el modelo de lenguaje lee esos pasajes y los usa, además de su propio conocimiento entrenado, para escribir la respuesta final. Esta mezcla de búsqueda y generación ayuda al modelo a mantenerse actualizado, reducir las conjeturas y citar hechos reales. Debido a que agrega información externa bajo demanda, RAG a menudo necesita menos ajuste fino y puede manejar temas que el modelo base nunca vio durante el entrenamiento.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "What Is RAG in AI and How to Use It?",
+        "title": "¿Qué es RAG en IA y Cómo Usarlo?",
         "url": "https://www.v7labs.com/blog/what-is-rag",
         "type": "article"
       },
       {
-        "title": "An Introduction to RAG and Simple & Complex RAG",
+        "title": "Una Introducción a RAG y RAG Simple y Complejo",
         "url": "https://medium.com/enterprise-rag/an-introduction-to-rag-and-simple-complex-rag-9c3aa9bd017b",
         "type": "article"
       },
       {
-        "title": "Learn RAG From Scratch",
+        "title": "Aprende RAG Desde Cero",
         "url": "https://www.youtube.com/watch?v=sVcwVQRHIc8",
         "type": "video"
       }
     ]
   },
   "B8dzg61TGaknuruBgkEJd": {
-    "title": "Pricing of Common Models",
-    "description": "When you use a large language model, you usually pay by the amount of text it reads and writes, counted in “tokens.” A token is about four characters or three-quarters of a word. Providers list a price per 1,000 tokens. For example, GPT-3.5 Turbo may cost around $0.002 per 1,000 tokens, while GPT-4 is much higher, such as $0.03 to $0.06 for prompts and $0.06 to $0.12 for replies. Smaller open-source models like Llama-2 can be free to use if you run them on your own computer, but you still pay for the hardware or cloud time. Vision or audio models often have extra fees because they use more compute. When planning costs, estimate the tokens in each call, multiply by the price, and add any hosting or storage charges.\n\nVisit the following resources to learn more:",
+    "title": "Precios de Modelos Comunes",
+    "description": "Cuando usas un modelo de lenguaje grande, generalmente pagas por la cantidad de texto que lee y escribe, contado en “tokens”. Un token equivale aproximadamente a cuatro caracteres o tres cuartas partes de una palabra. Los proveedores listan un precio por cada 1,000 tokens. Por ejemplo, GPT-3.5 Turbo puede costar alrededor de $0.002 por 1,000 tokens, mientras que GPT-4 es mucho más caro, como de $0.03 a $0.06 para prompts y de $0.06 a $0.12 para respuestas. Los modelos de código abierto más pequeños como Llama-2 pueden ser gratuitos si los ejecutas en tu propia computadora, pero aún pagas por el hardware o el tiempo en la nube. Los modelos de visión o audio a menudo tienen tarifas adicionales porque usan más cómputo. Al planificar los costos, estima los tokens en cada llamada, multiplica por el precio y agrega cualquier cargo de alojamiento o almacenamiento.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "OpenAI Pricing",
+        "title": "Precios de OpenAI",
         "url": "https://openai.com/api/pricing/",
         "type": "article"
       },
       {
-        "title": "Executive Guide To AI Agent Pricing",
+        "title": "Guía Ejecutiva Sobre Precios de Agentes de IA",
         "url": "https://www.forbes.com/councils/forbesbusinesscouncil/2025/01/28/executive-guide-to-ai-agent-pricing-winning-strategies-and-models-to-drive-growth/",
         "type": "article"
       },
       {
-        "title": "AI Pricing: How Much Does Artificial Intelligence Cost In 2025?",
+        "title": "Precios de IA: ¿Cuánto Cuesta la Inteligencia Artificial en 2025?",
         "url": "https://www.internetsearchinc.com/ai-pricing-how-much-does-artificial-intelligence-cost/",
         "type": "article"
       }
     ]
   },
   "aFZAm44nP5NefX_9TpT0A": {
-    "title": "What are AI Agents?",
-    "description": "An AI agent is a computer program or robot that can sense its surroundings, think about what it senses, and then act to reach a goal. It gathers data through cameras, microphones, or software inputs, decides what the data means using rules or learned patterns, and picks the best action to move closer to its goal. After acting, it checks the results and learns from them, so it can do better next time. Chatbots, self-driving cars, and game characters are all examples.\n\nVisit the following resources to learn more:",
+    "title": "¿Qué son los Agentes de IA?",
+    "description": "Un agente de IA es un programa de computadora o robot que puede percibir su entorno, pensar en lo que percibe y luego actuar para alcanzar un objetivo. Recopila datos a través de cámaras, micrófonos o entradas de software, decide qué significan los datos usando reglas o patrones aprendidos, y elige la mejor acción para acercarse a su objetivo. Después de actuar, comprueba los resultados y aprende de ellos, para poder hacerlo mejor la próxima vez. Los chatbots, los coches autónomos y los personajes de juegos son todos ejemplos.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "What are AI Agents? - Agents in Artificial Intelligence Explained",
+        "title": "¿Qué son los Agentes de IA? - Agentes en Inteligencia Artificial Explicados",
         "url": "https://aws.amazon.com/what-is/ai-agents/",
         "type": "article"
       },
       {
-        "title": "AI Agents Explained in Simple Terms for Beginners",
+        "title": "Agentes de IA Explicados en Términos Sencillos para Principiantes",
         "url": "https://www.geeky-gadgets.com/ai-agents-explained-for-beginners/",
         "type": "article"
       },
       {
-        "title": "What are AI Agents?",
+        "title": "¿Qué son los Agentes de IA?",
         "url": "https://www.youtube.com/watch?v=F8NKVhkZZWI",
         "type": "video"
       }
     ]
   },
   "2zsOUWJQ8e7wnoHmq1icG": {
-    "title": "What are Tools?",
-    "description": "Tools are extra skills or resources that an AI agent can call on to finish a job. A tool can be anything from a web search API to a calculator, a database, or a language-translation engine. The agent sends a request to the tool, gets the result, and then uses that result to move forward. Tools let a small core model handle tasks that would be hard or slow on its own. They also help keep answers current, accurate, and grounded in real data. Choosing the right tool and knowing when to use it are key parts of building a smart agent.\n\nVisit the following resources to learn more:",
+    "title": "¿Qué son las Herramientas?",
+    "description": "Las herramientas son habilidades o recursos adicionales a los que un agente de IA puede recurrir para completar un trabajo. Una herramienta puede ser cualquier cosa, desde una API de búsqueda web hasta una calculadora, una base de datos o un motor de traducción de idiomas. El agente envía una solicitud a la herramienta, obtiene el resultado y luego usa ese resultado para avanzar. Las herramientas permiten que un modelo central pequeño maneje tareas que serían difíciles o lentas por sí solo. También ayudan a mantener las respuestas actualizadas, precisas y basadas en datos reales. Elegir la herramienta adecuada y saber cuándo usarla son partes clave de la construcción de un agente inteligente.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "Compare 50+ AI Agent Tools in 2025 - AIMultiple",
+        "title": "Compara más de 50 Herramientas de Agentes de IA en 2025 - AIMultiple",
         "url": "https://research.aimultiple.com/ai-agent-tools/",
         "type": "article"
       },
       {
-        "title": "AI Agents Explained in Simple Terms for Beginners",
+        "title": "Agentes de IA Explicados en Términos Sencillos para Principiantes",
         "url": "https://www.geeky-gadgets.com/ai-agents-explained-for-beginners/",
         "type": "article"
       }
     ]
   },
   "Eih4eybuYB3C2So8K0AT3": {
-    "title": "Agent Loop",
-    "description": "An agent loop is the cycle that lets an AI agent keep working toward a goal. First, the agent gathers fresh data from its tools, sensors, or memory. Next, it updates its internal state and decides what to do, often by running a planning or reasoning step. Then it carries out the chosen action, such as calling an API, writing to a file, or sending a message. After acting, it checks the result and stores new information. The loop starts again with the latest data, so the agent can adjust to changes and improve over time. This fast repeat of observe–decide–act gives the agent its power.\n\nVisit the following resources to learn more:",
+    "title": "Bucle del Agente",
+    "description": "Un bucle de agente es el ciclo que permite a un agente de IA seguir trabajando hacia un objetivo. Primero, el agente recopila datos frescos de sus herramientas, sensores o memoria. A continuación, actualiza su estado interno y decide qué hacer, a menudo ejecutando un paso de planificación o razonamiento. Luego lleva a cabo la acción elegida, como llamar a una API, escribir en un archivo o enviar un mensaje. Después de actuar, comprueba el resultado y almacena nueva información. El bucle comienza de nuevo con los datos más recientes, para que el agente pueda ajustarse a los cambios y mejorar con el tiempo. Esta rápida repetición de observar–decidir–actuar le da al agente su poder.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "What is an Agent Loop?",
+        "title": "¿Qué es un Bucle de Agente?",
         "url": "https://huggingface.co/learn/agents-course/en/unit1/agent-steps-and-structure",
         "type": "article"
       },
       {
-        "title": "Let's Build your Own Agentic Loop",
+        "title": "Construyamos tu Propio Bucle Agéntico",
         "url": "https://www.reddit.com/r/AI_Agents/comments/1js1xjz/lets_build_our_own_agentic_loop_running_in_our/",
         "type": "article"
       }
     ]
   },
   "LU76AhCYDjxdBhpMQ4eMU": {
-    "title": "Perception / User Input",
-    "description": "Perception, also called user input, is the first step in an agent loop. The agent listens and gathers data from the outside world. This data can be text typed by a user, spoken words, camera images, sensor readings, or web content pulled through an API. The goal is to turn raw signals into a clear, usable form. The agent may clean the text, translate speech to text, resize an image, or drop noise from sensor values. Good perception means the agent starts its loop with facts, not guesses. If the input is wrong or unclear, later steps will also fail. So careful handling of perception keeps the whole agent loop on track.\n\nVisit the following resources to learn more:",
+    "title": "Percepción / Entrada del Usuario",
+    "description": "La percepción, también llamada entrada del usuario, es el primer paso en un bucle de agente. El agente escucha y recopila datos del mundo exterior. Estos datos pueden ser texto escrito por un usuario, palabras habladas, imágenes de cámara, lecturas de sensores o contenido web obtenido a través de una API. El objetivo es convertir las señales crudas en una forma clara y utilizable. El agente puede limpiar el texto, traducir voz a texto, redimensionar una imagen o eliminar ruido de los valores de los sensores. Una buena percepción significa que el agente comienza su bucle con hechos, no con suposiciones. Si la entrada es incorrecta o poco clara, los pasos posteriores también fallarán. Por lo tanto, el manejo cuidadoso de la percepción mantiene todo el bucle del agente en marcha.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "Perception in AI: Understanding Its Types and Importance",
+        "title": "Percepción en IA: Comprendiendo sus Tipos e Importancia",
         "url": "https://marktalks.com/perception-in-ai-understanding-its-types-and-importance/",
         "type": "article"
       },
       {
-        "title": "What Is AI Agent Perception? - IBM",
+        "title": "¿Qué es la Percepción del Agente de IA? - IBM",
         "url": "https://www.ibm.com/think/topics/ai-agent-perception",
         "type": "article"
       }
     ]
   },
   "ycPRgRYR4lEBQr_xxHKnM": {
-    "title": "Reason and Plan",
-    "description": "Reason and Plan is the moment when an AI agent thinks before it acts. The agent starts with a goal and the facts it already knows. It looks at these facts and asks, “What do I need to do next to reach the goal?” It breaks the goal into smaller steps, checks if each step makes sense, and orders them in a clear path. The agent may also guess what could go wrong and prepare backup steps. Once the plan feels solid, the agent is ready to move on and take the first action.\n\nVisit the following resources to learn more:",
+    "title": "Razonar y Planificar",
+    "description": "Razonar y Planificar es el momento en que un agente de IA piensa antes de actuar. El agente comienza con un objetivo y los hechos que ya conoce. Observa estos hechos y pregunta: “¿Qué necesito hacer a continuación para alcanzar el objetivo?” Divide el objetivo en pasos más pequeños, comprueba si cada paso tiene sentido y los ordena en un camino claro. El agente también puede adivinar qué podría salir mal y preparar pasos de respaldo. Una vez que el plan se siente sólido, el agente está listo para avanzar y tomar la primera acción.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "ReAct: Synergizing Reasoning and Acting in Language Models",
+        "title": "ReAct: Sinergizando Razonamiento y Actuación en Modelos de Lenguaje",
         "url": "https://react-lm.github.io/",
         "type": "article"
       },
       {
-        "title": "ReAct Systems: Enhancing LLMs with Reasoning and Action",
+        "title": "Sistemas ReAct: Mejorando LLMs con Razonamiento y Acción",
         "url": "https://learnprompting.org/docs/agents/react",
         "type": "article"
       }
     ]
   },
   "sHYd4KsKlmw5Im3nQ19W8": {
-    "title": "Acting / Tool Invocation",
-    "description": "Acting, also called tool invocation, is the step where the AI chooses a tool and runs it to get real-world data or to change something. The agent looks at its current goal and the plan it just made. It then picks the best tool, such as a web search, a database query, or a calculator. The agent fills in the needed inputs and sends the call. The external system does the heavy work and returns a result. Acting ends when the agent stores that result so it can think about the next move.\n\nVisit the following resources to learn more:",
+    "title": "Actuación / Invocación de Herramientas",
+    "description": "La actuación, también llamada invocación de herramientas, es el paso donde la IA elige una herramienta y la ejecuta para obtener datos del mundo real o para cambiar algo. El agente observa su objetivo actual y el plan que acaba de hacer. Luego elige la mejor herramienta, como una búsqueda web, una consulta de base de datos o una calculadora. El agente completa las entradas necesarias y envía la llamada. El sistema externo realiza el trabajo pesado y devuelve un resultado. La actuación termina cuando el agente almacena ese resultado para poder pensar en el siguiente movimiento.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "What are Tools in AI Agents?",
+        "title": "¿Qué son las Herramientas en los Agentes de IA?",
         "url": "https://huggingface.co/learn/agents-course/en/unit1/tools",
         "type": "article"
       },
       {
-        "title": "What is Tool Calling in Agents?",
+        "title": "¿Qué es la Invocación de Herramientas en los Agentes?",
         "url": "https://www.useparagon.com/blog/ai-building-blocks-what-is-tool-calling-a-guide-for-pms",
         "type": "article"
       }
     ]
   },
   "ZJTrun3jK3zBGOTm1jdMI": {
-    "title": "Observation & Reflection",
-    "description": "Observation and reflection form the thinking pause in an AI agent’s loop. First, the agent looks at the world around it, gathers fresh data, and sees what has changed. It then pauses to ask, “What does this new information mean for my goal?” During this short check, the agent updates its memory, spots errors, and ranks what matters most. These steps guide wiser plans and actions in the next cycle. Without careful observation and reflection, the agent would rely on old or wrong facts and soon drift off course.\n\nVisit the following resources to learn more:",
+    "title": "Observación y Reflexión",
+    "description": "La observación y la reflexión forman la pausa de pensamiento en el bucle de un agente de IA. Primero, el agente observa el mundo que lo rodea, recopila datos frescos y ve qué ha cambiado. Luego hace una pausa para preguntar: “¿Qué significa esta nueva información para mi objetivo?” Durante esta breve verificación, el agente actualiza su memoria, detecta errores y clasifica lo que más importa. Estos pasos guían planes y acciones más sabios en el próximo ciclo. Sin una observación y reflexión cuidadosas, el agente dependería de hechos antiguos o incorrectos y pronto se desviaría del rumbo.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "Best Practices for Prompting and Self-checking",
+        "title": "Mejores Prácticas para la Creación de Prompts y la Autoverificación",
         "url": "https://platform.openai.com/docs/guides/prompt-engineering",
         "type": "article"
       },
       {
-        "title": "Self-Reflective AI: Building Agents That Learn by Observing Themselves",
+        "title": "IA Autorreflexiva: Construyendo Agentes que Aprenden Observándose a Sí Mismos",
         "url": "https://arxiv.org/abs/2302.14045",
         "type": "article"
       }
     ]
   },
   "PPdAutqJF5G60Eg9lYBND": {
-    "title": "Personal assistant",
-    "description": "A personal assistant AI agent is a smart program that helps one person manage daily tasks. It can check a calendar, set reminders, and send alerts so you never miss a meeting. It can read emails, highlight key points, and even draft quick replies. If you ask a question, it searches trusted sources and gives a short answer. It can order food, book rides, or shop online when you give simple voice or text commands. Because it learns your habits, it suggests the best time to work, rest, or travel. All these actions run in the background, saving you time and reducing stress.\n\nVisit the following resources to learn more:",
+    "title": "Asistente personal",
+    "description": "Un agente de IA de asistente personal es un programa inteligente que ayuda a una persona a gestionar las tareas diarias. Puede consultar un calendario, establecer recordatorios y enviar alertas para que nunca te pierdas una reunión. Puede leer correos electrónicos, resaltar puntos clave e incluso redactar respuestas rápidas. Si haces una pregunta, busca en fuentes confiables y da una respuesta corta. Puede pedir comida, reservar viajes o comprar en línea cuando das comandos simples de voz o texto. Como aprende tus hábitos, sugiere el mejor momento para trabajar, descansar o viajar. Todas estas acciones se ejecutan en segundo plano, ahorrándote tiempo y reduciendo el estrés.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "A Complete Guide on AI-powered Personal Assistants",
+        "title": "Una Guía Completa sobre Asistentes Personales Impulsados por IA",
         "url": "https://medium.com/@alexander_clifford/a-complete-guide-on-ai-powered-personal-assistants-with-examples-2f5cd894d566",
         "type": "article"
       },
       {
-        "title": "9 Best AI Personal Assistants for Work, Chat and Home",
+        "title": "Los 9 Mejores Asistentes Personales de IA para el Trabajo, Chat y Hogar",
         "url": "https://saner.ai/best-ai-personal-assistants/",
         "type": "article"
       }
     ]
   },
   "PK8w31GlvtmAuU92sHaqr": {
-    "title": "Code generation",
-    "description": "Code-generation agents take a plain language request, understand the goal, and then write or edit source code to meet it. They can build small apps, add features, fix bugs, refactor old code, write tests, or translate code from one language to another. This saves time for developers, helps beginners learn, and reduces human error. Teams use these agents inside code editors, chat tools, and automated pipelines. By handling routine coding tasks, the agents free people to focus on design, logic, and user needs.\n\nVisit the following resources to learn more:",
+    "title": "Generación de código",
+    "description": "Los agentes de generación de código toman una solicitud en lenguaje sencillo, comprenden el objetivo y luego escriben o editan el código fuente para cumplirlo. Pueden crear pequeñas aplicaciones, agregar funciones, corregir errores, refactorizar código antiguo, escribir pruebas o traducir código de un idioma a otro. Esto ahorra tiempo a los desarrolladores, ayuda a los principiantes a aprender y reduce el error humano. Los equipos usan estos agentes dentro de editores de código, herramientas de chat y canalizaciones automatizadas. Al encargarse de tareas de codificación rutinarias, los agentes liberan a las personas para que se concentren en el diseño, la lógica y las necesidades del usuario.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "Multi-Agent-based Code Generation",
+        "title": "Generación de Código Basada en Múltiples Agentes",
         "url": "https://arxiv.org/abs/2312.13010",
         "type": "article"
       },
       {
-        "title": "From Prompt to Production: Github Blog",
+        "title": "Del Prompt a la Producción: Blog de Github",
         "url": "https://github.blog/ai-and-ml/github-copilot/from-prompt-to-production-building-a-landing-page-with-copilot-agent-mode/",
         "type": "article"
       },
@@ -569,16 +569,16 @@
     ]
   },
   "wKYEaPWNsR30TIpHaxSsq": {
-    "title": "Data analysis",
-    "description": "AI agents can automate data analysis by pulling information from files, databases, or live streams. They clean the data by spotting missing values, outliers, and making smart corrections. After cleaning, agents find patterns like sales spikes or sensor drops and can build charts or dashboards. Some run basic statistics, others apply machine learning to predict trends. Agents can also send alerts if numbers go beyond set limits, helping people stay informed without constant monitoring.\n\nVisit the following resources to learn more:",
+    "title": "Análisis de datos",
+    "description": "Los agentes de IA pueden automatizar el análisis de datos extrayendo información de archivos, bases de datos o transmisiones en vivo. Limpian los datos detectando valores faltantes, valores atípicos y realizando correcciones inteligentes. Después de la limpieza, los agentes encuentran patrones como picos de ventas o caídas de sensores y pueden crear gráficos o paneles. Algunos ejecutan estadísticas básicas, otros aplican aprendizaje automático para predecir tendencias. Los agentes también pueden enviar alertas si los números superan los límites establecidos, ayudando a las personas a mantenerse informadas sin un monitoreo constante.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "How AI Will Transform Data Analysis in 2025",
+        "title": "Cómo la IA Transformará el Análisis de Datos en 2025",
         "url": "https://www.devfi.com/ai-transform-data-analysis-2025/",
         "type": "article"
       },
       {
-        "title": "How AI Has Changed The World Of Analytics And Data Science",
+        "title": "Cómo la IA ha Cambiado el Mundo de la Analítica y la Ciencia de Datos",
         "url": "https://www.forbes.com/councils/forbestechcouncil/2025/01/28/how-ai-has-changed-the-world-of-analytics-and-data-science/k",
         "type": "article"
       }
@@ -586,579 +586,579 @@
   },
   "5oLc-235bvKhApxzYFkEc": {
     "title": "Web Scraping / Crawling",
-    "description": "Web scraping and crawling let an AI agent collect data from many web pages without human help. The agent sends a request to a page, reads the HTML, and pulls out parts you ask for, such as prices, news headlines, or product details. It can then follow links on the page to reach more pages and repeat the same steps. This loop builds a large, up-to-date dataset in minutes or hours instead of days. Companies use it to track market prices, researchers use it to gather facts or trends, and developers use it to feed fresh data into other AI models. Good scraping code also respects site rules like robots.txt and avoids hitting servers too fast, so it works smoothly and fairly.\n\nVisit the following resources to learn more:",
+    "description": "El web scraping y el crawling permiten a un agente de IA recopilar datos de muchas páginas web sin ayuda humana. El agente envía una solicitud a una página, lee el HTML y extrae las partes que solicitas, como precios, titulares de noticias o detalles de productos. Luego puede seguir los enlaces de la página para llegar a más páginas y repetir los mismos pasos. Este bucle crea un conjunto de datos grande y actualizado en minutos u horas en lugar de días. Las empresas lo utilizan para rastrear los precios del mercado, los investigadores para recopilar hechos o tendencias, y los desarrolladores para alimentar con datos frescos otros modelos de IA. Un buen código de scraping también respeta las reglas del sitio como robots.txt y evita saturar los servidores demasiado rápido, por lo que funciona sin problemas y de manera justa.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "Crawl AI - Build Your AI With One Prompt",
+        "title": "Crawl AI - Construye tu IA con un Prompt",
         "url": "https://www.crawlai.org/",
         "type": "article"
       },
       {
-        "title": "AI-Powered Web Scraper with Crawl4AI and DeepSeek",
+        "title": "Web Scraper Impulsado por IA con Crawl4AI y DeepSeek",
         "url": "https://brightdata.com/blog/web-data/crawl4ai-and-deepseek-web-scraping",
         "type": "article"
       },
       {
-        "title": "Best Web Scraping Tools for AI Applications",
+        "title": "Las Mejores Herramientas de Web Scraping para Aplicaciones de IA",
         "url": "https://www.thetoolnerd.com/p/best-web-scraping-tools-for-ai-applications",
         "type": "article"
       },
       {
-        "title": "8 Best AI Web Scraping Tools I Tried - HubSpot Blog",
+        "title": "Las 8 Mejores Herramientas de Web Scraping con IA que Probé - Blog de HubSpot",
         "url": "https://blog.hubspot.com/website/ai-web-scraping",
         "type": "article"
       }
     ]
   },
   "ok8vN7VtCgyef5x6aoQaL": {
-    "title": "NPC / Game AI",
-    "description": "Game studios use AI agents to control non-player characters (NPCs). The agent observes the game state and decides actions like moving, speaking, or fighting. It can shift tactics when the player changes strategy, keeping battles fresh instead of predictable. A quest giver might use an agent to offer hints that fit the player’s progress. In open-world games, agents guide crowds to move around obstacles, set new goals, and react to threats, making towns feel alive. Designers save time by writing broad rules and letting agents fill in details instead of hand-coding every scene. Smarter NPC behavior keeps players engaged and boosts replay value.\n\nVisit the following resources to learn more:",
+    "title": "NPC / IA de Juegos",
+    "description": "Los estudios de juegos utilizan agentes de IA para controlar personajes no jugadores (NPC). El agente observa el estado del juego y decide acciones como moverse, hablar o luchar. Puede cambiar de táctica cuando el jugador cambia de estrategia, manteniendo las batallas frescas en lugar de predecibles. Un dador de misiones podría usar un agente para ofrecer pistas que se ajusten al progreso del jugador. En los juegos de mundo abierto, los agentes guían a las multitudes para moverse alrededor de obstáculos, establecer nuevos objetivos y reaccionar a las amenazas, haciendo que las ciudades se sientan vivas. Los diseñadores ahorran tiempo escribiendo reglas generales y dejando que los agentes completen los detalles en lugar de codificar manualmente cada escena. Un comportamiento de NPC más inteligente mantiene a los jugadores comprometidos y aumenta el valor de rejugabilidad.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "Unity – AI for NPCs",
+        "title": "Unity – IA para NPCs",
         "url": "https://dev.epicgames.com/documentation/en-us/unreal-engine/artificial-intelligence-in-unreal-engine?application_version=5.3",
         "type": "article"
       },
       {
-        "title": "AI-Driven NPCs: The Future of Gaming Explained",
+        "title": "NPCs Impulsados por IA: El Futuro de los Videojuegos Explicado",
         "url": "https://www.capermint.com/blog/everything-you-need-to-know-about-non-player-character-npc/",
         "type": "article"
       }
     ]
   },
   "Bn_BkthrVX_vOuwQzvPZa": {
-    "title": "Max Length",
-    "description": "Max Length sets the maximum number of tokens a language model can generate in one reply. Tokens are pieces of text—roughly 100 tokens equals a short paragraph. A small limit saves time and cost but risks cutting answers short. A large limit allows full, detailed replies but needs more compute and can lose focus. Choose limits based on the task: short limits for tweets, longer ones for articles. Tuning Max Length carefully helps balance clarity, speed, and cost.\n\nVisit the following resources to learn more:",
+    "title": "Longitud Máxima",
+    "description": "La Longitud Máxima establece el número máximo de tokens que un modelo de lenguaje puede generar en una respuesta. Los tokens son piezas de texto; aproximadamente 100 tokens equivalen a un párrafo corto. Un límite pequeño ahorra tiempo y costos, pero corre el riesgo de truncar las respuestas. Un límite grande permite respuestas completas y detalladas, pero necesita más cómputo y puede perder el enfoque. Elige los límites según la tarea: límites cortos para tuits, más largos para artículos. Ajustar cuidadosamente la Longitud Máxima ayuda a equilibrar la claridad, la velocidad y el costo.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "OpenAI Token Usage",
+        "title": "Uso de Tokens de OpenAI",
         "url": "https://platform.openai.com/docs/guides/gpt/managing-tokens",
         "type": "article"
       },
       {
-        "title": "Size and Max Token Limits",
+        "title": "Límites de Tamaño y Tokens Máximos",
         "url": "https://docs.anthropic.com/claude/docs/size-and-token-limits",
         "type": "article"
       },
       {
-        "title": "Utilising Max Token Context Window of Anthropic Claude",
+        "title": "Utilizando la Ventana de Contexto de Tokens Máximos de Anthropic Claude",
         "url": "https://medium.com/@nampreetsingh/utilising-max-token-context-window-of-anthropic-claude-on-amazon-bedrock-7377d94b2dfa",
         "type": "article"
       },
       {
-        "title": "Controlling the Length of OpenAI Model Responses",
+        "title": "Controlando la Longitud de las Respuestas del Modelo OpenAI",
         "url": "https://help.openai.com/en/articles/5072518-controlling-the-length-of-openai-model-responses",
         "type": "article"
       },
       {
-        "title": "Max Model Length in AI",
+        "title": "Longitud Máxima del Modelo en IA",
         "url": "https://www.restack.io/p/ai-model-answer-max-model-length-cat-ai",
         "type": "article"
       },
       {
-        "title": "Understanding ChatGPT/OpenAI Tokens",
+        "title": "Entendiendo los Tokens de ChatGPT/OpenAI",
         "url": "https://youtu.be/Mo3NV5n1yZk",
         "type": "video"
       }
     ]
   },
   "Y8EqzFx3qxtrSh7bWbbV8": {
-    "title": "What is Prompt Engineering",
-    "description": "Prompt engineering is the skill of writing clear questions or instructions so that an AI system gives the answer you want. It means choosing the right words, adding enough detail, and giving examples when needed. A good prompt tells the AI what role to play, what style to use, and what facts to include or avoid. By testing and refining the prompt, you can improve the quality, accuracy, and usefulness of the AI’s response. In short, prompt engineering is guiding the AI with well-designed text so it can help you better.\n\nVisit the following resources to learn more:",
+    "title": "¿Qué es la Ingeniería de Prompts?",
+    "description": "La ingeniería de prompts es la habilidad de escribir preguntas o instrucciones claras para que un sistema de IA dé la respuesta que deseas. Significa elegir las palabras correctas, agregar suficientes detalles y dar ejemplos cuando sea necesario. Un buen prompt le dice a la IA qué rol desempeñar, qué estilo usar y qué hechos incluir o evitar. Al probar y refinar el prompt, puedes mejorar la calidad, precisión y utilidad de la respuesta de la IA. En resumen, la ingeniería de prompts es guiar a la IA con texto bien diseñado para que pueda ayudarte mejor.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "Visit Dedicated Prompt Engineering Roadmap",
+        "title": "Visita el Roadmap Dedicado de Ingeniería de Prompts",
         "url": "https://roadmap.sh/prompt-engineering",
         "type": "article"
       },
       {
-        "title": "What is Prompt Engineering? - AI Prompt Engineering Explained - AWS",
+        "title": "¿Qué es la Ingeniería de Prompts? - Ingeniería de Prompts de IA Explicada - AWS",
         "url": "https://aws.amazon.com/what-is/prompt-engineering/",
         "type": "article"
       },
       {
-        "title": "What is Prompt Engineering? A Detailed Guide For 2025",
+        "title": "¿Qué es la Ingeniería de Prompts? Una Guía Detallada para 2025",
         "url": "https://www.datacamp.com/blog/what-is-prompt-engineering-the-future-of-ai-communication",
         "type": "article"
       }
     ]
   },
   "qFKFM2qNPEN7EoD0V-1SM": {
-    "title": "Be specific in what you want",
-    "description": "When you ask an AI to do something, clear and exact words help it give the answer you want. State the goal, the format, and any limits up front. Say who the answer is for, how long it should be, and what to leave out. If numbers, dates, or sources matter, name them. For example, rather than “Explain World War II,” try “List three key events of World War II with dates and one short fact for each.” Being this precise cuts down on guesswork, avoids unwanted extra detail, and saves time by reducing follow-up questions.\n\nVisit the following resources to learn more:",
+    "title": "Sé específico en lo que quieres",
+    "description": "Cuando le pides a una IA que haga algo, las palabras claras y exactas la ayudan a dar la respuesta que deseas. Indica el objetivo, el formato y cualquier límite desde el principio. Di para quién es la respuesta, cuán larga debe ser y qué omitir. Si los números, fechas o fuentes importan, menciónalos. Por ejemplo, en lugar de “Explica la Segunda Guerra Mundial”, prueba “Enumera tres eventos clave de la Segunda Guerra Mundial con fechas y un hecho breve para cada uno”. Ser así de preciso reduce las conjeturas, evita detalles adicionales no deseados y ahorra tiempo al reducir las preguntas de seguimiento.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "Prompt Engineering Guide",
+        "title": "Guía de Ingeniería de Prompts",
         "url": "https://www.promptingguide.ai/",
         "type": "article"
       },
       {
-        "title": "AI Prompting Examples, Templates, and Tips For Educators",
+        "title": "Ejemplos de Prompts de IA, Plantillas y Consejos para Educadores",
         "url": "https://honorlock.com/blog/education-ai-prompt-writing/",
         "type": "article"
       },
       {
-        "title": "How to Ask AI for Anything: The Art of Prompting",
+        "title": "Cómo Pedirle Cualquier Cosa a la IA: El Arte de Crear Prompts",
         "url": "https://sixtyandme.com/using-ai-prompts/",
         "type": "article"
       }
     ]
   },
   "6I42CoeWX-kkFXTKAY7rw": {
-    "title": "Provide additional context",
-    "description": "Provide additional context means giving the AI enough background facts, constraints, and goals so it can reply in the way you need. Start by naming the topic and the purpose of the answer. Add who the answer is for, the tone you want, and any limits such as length, format, or style. List key facts, data, or examples that matter to the task. This extra detail stops the model from guessing and keeps replies on target. Think of it like guiding a new teammate: share the details they need, but keep them short and clear.\n\nVisit the following resources to learn more:",
+    "title": "Proporciona contexto adicional",
+    "description": "Proporcionar contexto adicional significa darle a la IA suficientes hechos de fondo, restricciones y objetivos para que pueda responder de la manera que necesitas. Comienza nombrando el tema y el propósito de la respuesta. Agrega para quién es la respuesta, el tono que deseas y cualquier límite como longitud, formato o estilo. Enumera hechos clave, datos o ejemplos que sean importantes para la tarea. Este detalle adicional evita que el modelo adivine y mantiene las respuestas enfocadas. Piénsalo como guiar a un nuevo compañero de equipo: comparte los detalles que necesitan, pero mantenlos cortos y claros.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "What is Context in Prompt Engineering?",
+        "title": "¿Qué es el Contexto en la Ingeniería de Prompts?",
         "url": "https://www.godofprompt.ai/blog/what-is-context-in-prompt-engineering",
         "type": "article"
       },
       {
-        "title": "The Importance of Context for Reliable AI Systems",
+        "title": "La Importancia del Contexto para Sistemas de IA Confiables",
         "url": "https://medium.com/mathco-ai/the-importance-of-context-for-reliable-ai-systems-and-how-to-provide-context-009bd1ac7189/",
         "type": "article"
       },
       {
-        "title": "Context Engineering: Why Feeding AI the Right Context Matters",
+        "title": "Ingeniería de Contexto: Por Qué es Importante Alimentar a la IA con el Contexto Correcto",
         "url": "https://inspirednonsense.com/context-engineering-why-feeding-ai-the-right-context-matters-353e8f87d6d3",
         "type": "article"
       }
     ]
   },
   "sUwdtOX550tSdceaeFPmF": {
-    "title": "Use relevant technical terms",
-    "description": "When a task involves a special field such as law, medicine, or computer science, include the correct domain words in your prompt so the AI knows exactly what you mean. Ask for “O(n log n) sorting algorithms” instead of just “fast sorts,” or “HTTP status code 404” instead of “page not found error.” The right term narrows the topic, removes guesswork, and points the model toward the knowledge base you need. It also keeps the answer at the right level, because the model sees you understand the field and will reply with matching depth. Check spelling and letter case; “SQL” and “sql” are seen the same, but “Sequel” is not. Do not overload the prompt with buzzwords—add only the words that truly matter. The goal is clear language plus the exact technical labels the subject uses.\n\nVisit the following resources to learn more:",
+    "title": "Usa términos técnicos relevantes",
+    "description": "Cuando una tarea involucra un campo especial como derecho, medicina o informática, incluye las palabras correctas del dominio en tu prompt para que la IA sepa exactamente a qué te refieres. Pide “algoritmos de ordenación O(n log n)” en lugar de solo “ordenaciones rápidas”, o “código de estado HTTP 404” en lugar de “error de página no encontrada”. El término correcto acota el tema, elimina las conjeturas y dirige el modelo hacia la base de conocimientos que necesitas. También mantiene la respuesta en el nivel adecuado, porque el modelo ve que entiendes el campo y responderá con la profundidad correspondiente. Revisa la ortografía y el uso de mayúsculas y minúsculas; “SQL” y “sql” se consideran iguales, pero “Sequel” no. No sobrecargues el prompt con palabras de moda, agrega solo las palabras que realmente importan. El objetivo es un lenguaje claro más las etiquetas técnicas exactas que utiliza el tema.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "AI Terms Glossary: AI Terms To Know In 2024",
+        "title": "Glosario de Términos de IA: Términos de IA que Debes Conocer en 2024",
         "url": "https://www.moveworks.com/us/en/resources/ai-terms-glossary",
         "type": "article"
       },
       {
-        "title": "15 Essential AI Agent Terms You Must Know",
+        "title": "15 Términos Esenciales sobre Agentes de IA que Debes Conocer",
         "url": "https://shivammore.medium.com/15-essential-ai-agent-terms-you-must-know-6bfc2f332f6d",
         "type": "article"
       },
       {
-        "title": "AI Agent Examples & Use Cases: Real Applications in 2025",
+        "title": "Ejemplos y Casos de Uso de Agentes de IA: Aplicaciones Reales en 2025",
         "url": "https://eastgate-software.com/ai-agent-examples-use-cases-real-applications-in-2025/",
         "type": "article"
       }
     ]
   },
   "yulzE4ZNLhXOgHhG7BtZQ": {
-    "title": "Use Examples in your Prompt",
-    "description": "A clear way to guide an AI is to place one or two short samples inside your prompt. Show a small input and the exact output you expect. The AI studies these pairs and copies their pattern. Use plain words in the sample, keep the format steady, and label each part so the model knows which is which. If you need a list, show a list; if you need a table, include a small table. Good examples cut guesswork, reduce errors, and save you from writing long rules.\n\nVisit the following resources to learn more:",
+    "title": "Usa Ejemplos en tu Prompt",
+    "description": "Una forma clara de guiar a una IA es colocar una o dos muestras cortas dentro de tu prompt. Muestra una entrada pequeña y la salida exacta que esperas. La IA estudia estos pares y copia su patrón. Usa palabras sencillas en la muestra, mantén el formato estable y etiqueta cada parte para que el modelo sepa cuál es cuál. Si necesitas una lista, muestra una lista; si necesitas una tabla, incluye una tabla pequeña. Los buenos ejemplos reducen las conjeturas, disminuyen los errores y te ahorran escribir reglas largas.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "10 Real-World AI Agent Examples in 2025",
+        "title": "10 Ejemplos de Agentes de IA del Mundo Real en 2025",
         "url": "https://www.chatbase.co/blog/ai-agent-examples",
         "type": "article"
       },
       {
-        "title": "GPT-4.1 Prompting Guide",
+        "title": "Guía de Creación de Prompts para GPT-4.1",
         "url": "https://cookbook.openai.com/examples/gpt4-1_prompting_guide",
         "type": "article"
       },
       {
-        "title": "AI Agent Examples & Use Cases: Real Applications in 2025",
+        "title": "Ejemplos y Casos de Uso de Agentes de IA: Aplicaciones Reales en 2025",
         "url": "https://eastgate-software.com/ai-agent-examples-use-cases-real-applications-in-2025/",
         "type": "article"
       }
     ]
   },
   "noTuUFnHSBzn7GKG9UZEi": {
-    "title": "Iterate and Test your Prompts",
-    "description": "After you write a first prompt, treat it as a draft, not the final version. Run it with the AI, check the output, and note what is missing, wrong, or confusing. Change one thing at a time, such as adding an example, a limit on length, or a tone request. Test again and see if the result gets closer to what you want. Keep a record of each change and its effect, so you can learn patterns that work. Stop when the output is clear, correct, and repeatable. This loop of try, observe, adjust, and retry turns a rough prompt into a strong one.\n\nVisit the following resources to learn more:",
+    "title": "Itera y Prueba tus Prompts",
+    "description": "Después de escribir un primer prompt, trátalo como un borrador, no como la versión final. Ejecútalo con la IA, revisa el resultado y anota lo que falta, está mal o es confuso. Cambia una cosa a la vez, como agregar un ejemplo, un límite de longitud o una solicitud de tono. Prueba de nuevo y ve si el resultado se acerca más a lo que deseas. Mantén un registro de cada cambio y su efecto, para que puedas aprender patrones que funcionan. Detente cuando el resultado sea claro, correcto y repetible. Este bucle de probar, observar, ajustar y reintentar convierte un prompt preliminar en uno sólido.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "Prompt Engineering Best Practices",
+        "title": "Mejores Prácticas de Ingeniería de Prompts",
         "url": "https://www.deeplearning.ai/short-courses/chatgpt-prompt-engineering-for-developers/",
         "type": "course"
       },
       {
-        "title": "Master Iterative Prompting: A Guide",
+        "title": "Domina la Creación Iterativa de Prompts: Una Guía",
         "url": "https://blogs.vreamer.space/master-iterative-prompting-a-guide-to-more-effective-interactions-with-ai-50a736eaec38",
         "type": "article"
       },
       {
-        "title": "Prompt Engineering: The Iterative Process",
+        "title": "Ingeniería de Prompts: El Proceso Iterativo",
         "url": "https://www.youtube.com/watch?v=dOxUroR57xs",
         "type": "video"
       }
     ]
   },
   "wwHHlEoPAx0TLxbtY6nMA": {
-    "title": "Specify Length, format etc",
-    "description": "When you give a task to an AI, make clear how long the answer should be and what shape it must take. Say “Write 120 words” or “Give the steps as a numbered list.” If you need a table, state the column names and order. If you want bullet points, mention that. Telling the AI to use plain text, JSON, or markdown stops guesswork and saves time. Clear limits on length keep the reply focused. A fixed format makes it easier for people or other software to read and use the result. Always put these rules near the start of your prompt so the AI sees them as important.\n\nVisit the following resources to learn more:",
+    "title": "Especifica Longitud, formato, etc.",
+    "description": "Cuando le das una tarea a una IA, deja en claro cuán larga debe ser la respuesta y qué forma debe tomar. Di “Escribe 120 palabras” o “Da los pasos como una lista numerada”. Si necesitas una tabla, indica los nombres de las columnas y el orden. Si quieres viñetas, menciónalo. Decirle a la IA que use texto sin formato, JSON o markdown evita las conjeturas y ahorra tiempo. Límites claros de longitud mantienen la respuesta enfocada. Un formato fijo facilita que las personas u otro software lean y usen el resultado. Siempre coloca estas reglas cerca del inicio de tu prompt para que la IA las vea como importantes.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "Mastering Prompt Engineering: Format, Length, and Audience",
+        "title": "Dominando la Ingeniería de Prompts: Formato, Longitud y Audiencia",
         "url": "https://techlasi.com/savvy/mastering-prompt-engineering-format-length-and-audience-examples-for-2024/",
         "type": "article"
       },
       {
-        "title": "Ultimate Guide to Prompt Engineering",
+        "title": "Guía Definitiva de Ingeniería de Prompts",
         "url": "https://promptdrive.ai/prompt-engineering/",
         "type": "article"
       }
     ]
   },
   "qakbxB8xe7Y8gejC5cZnK": {
-    "title": "Tool Definition",
-    "description": "A tool is any skill or function that an AI agent can call to get a job done. It can be as simple as a calculator for math or as complex as an API that fetches live weather data. Each tool has a name, a short description of what it does, and a clear list of the inputs it needs and the outputs it returns. The agent’s planner reads this definition to decide when to use the tool. Good tool definitions are precise and leave no room for doubt, so the agent will not guess or misuse them. They also set limits, like how many times a tool can be called or how much data can be pulled, which helps control cost and errors. Think of a tool definition as a recipe card the agent follows every time it needs that skill.\n\nVisit the following resources to learn more:",
+    "title": "Definición de Herramienta",
+    "description": "Una herramienta es cualquier habilidad o función a la que un agente de IA puede recurrir para realizar un trabajo. Puede ser tan simple como una calculadora para matemáticas o tan compleja como una API que obtiene datos meteorológicos en vivo. Cada herramienta tiene un nombre, una breve descripción de lo que hace y una lista clara de las entradas que necesita y las salidas que devuelve. El planificador del agente lee esta definición para decidir cuándo usar la herramienta. Las buenas definiciones de herramientas son precisas y no dejan lugar a dudas, para que el agente no adivine ni las use incorrectamente. También establecen límites, como cuántas veces se puede llamar a una herramienta o cuántos datos se pueden extraer, lo que ayuda a controlar costos y errores. Piensa en una definición de herramienta como una tarjeta de receta que el agente sigue cada vez que necesita esa habilidad.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "Understanding the Agent Function in AI: Key Roles and Responsibilities",
+        "title": "Comprendiendo la Función del Agente en IA: Roles y Responsabilidades Clave",
         "url": "https://pingax.com/ai/agent/function/understanding-the-agent-function-in-ai-key-roles-and-responsibilities/",
         "type": "article"
       },
       {
-        "title": "What is an AI Tool?",
+        "title": "¿Qué es una Herramienta de IA?",
         "url": "https://www.synthesia.io/glossary/ai-tool",
         "type": "article"
       }
     ]
   },
   "kBtqT8AduLoYDWopj-V9_": {
-    "title": "Web Search",
-    "description": "Web search lets an AI agent pull fresh facts, news, and examples from the internet while it is working. The agent turns a user request into search words, sends them to a search engine, and reads the list of results. It then follows the most promising links, grabs the page text, and picks out the parts that answer the task. This helps the agent handle topics that were not in its training data, update old knowledge, or double-check details. Web search covers almost any subject and is much faster than manual research, but the agent must watch for ads, bias, or wrong pages and cross-check sources to stay accurate.\n\nVisit the following resources to learn more:",
+    "title": "Búsqueda Web",
+    "description": "La búsqueda web permite a un agente de IA extraer hechos frescos, noticias y ejemplos de Internet mientras está trabajando. El agente convierte una solicitud del usuario en palabras de búsqueda, las envía a un motor de búsqueda y lee la lista de resultados. Luego sigue los enlaces más prometedores, toma el texto de la página y selecciona las partes que responden a la tarea. Esto ayuda al agente a manejar temas que no estaban en sus datos de entrenamiento, actualizar conocimientos antiguos o verificar detalles. La búsqueda web cubre casi cualquier tema y es mucho más rápida que la investigación manual, pero el agente debe estar atento a anuncios, sesgos o páginas incorrectas y verificar las fuentes para mantenerse preciso.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "8 Best AI Search Engines for 2025",
+        "title": "Los 8 Mejores Motores de Búsqueda con IA para 2025",
         "url": "https://usefulai.com/tools/ai-search-engines",
         "type": "article"
       },
       {
-        "title": "Web Search Agent - PraisonAI Documentation",
+        "title": "Agente de Búsqueda Web - Documentación de PraisonAI",
         "url": "https://docs.praison.ai/agents/websearch",
         "type": "article"
       }
     ]
   },
   "mS0EVCkWuPN_GkVPng4A2": {
-    "title": "Code Execution / REPL",
-    "description": "Code Execution or REPL (Read-Eval-Print Loop) lets an AI agent run small pieces of code on demand, see the result right away, and use that result to decide what to do next. The agent “reads” the code, “evaluates” it in a safe sandbox, “prints” the output, and then loops back for more input. With this tool the agent can test ideas, perform math, transform text, call APIs, or inspect data without waiting for a full build or deployment. Python, JavaScript, or even shell commands are common choices because they start fast and have many libraries. Quick feedback helps the agent catch errors early and refine its plan step by step. Sandboxing keeps the host system safe by blocking dangerous actions such as deleting files or making forbidden network calls. Overall, a Code Execution / REPL tool gives the agent a fast, flexible workbench for problem-solving.\n\nVisit the following resources to learn more:",
+    "title": "Ejecución de Código / REPL",
+    "description": "La Ejecución de Código o REPL (Bucle de Lectura-Evaluación-Impresión) permite a un agente de IA ejecutar pequeños fragmentos de código bajo demanda, ver el resultado de inmediato y usar ese resultado para decidir qué hacer a continuación. El agente “lee” el código, lo “evalúa” en un sandbox seguro, “imprime” la salida y luego vuelve al bucle para más entrada. Con esta herramienta, el agente puede probar ideas, realizar cálculos matemáticos, transformar texto, llamar a API o inspeccionar datos sin esperar una compilación o implementación completa. Python, JavaScript o incluso comandos de shell son opciones comunes porque se inician rápidamente y tienen muchas bibliotecas. La retroalimentación rápida ayuda al agente a detectar errores temprano y refinar su plan paso a paso. El sandboxing mantiene seguro el sistema anfitrión al bloquear acciones peligrosas como eliminar archivos o realizar llamadas de red prohibidas. En general, una herramienta de Ejecución de Código / REPL le da al agente un banco de trabajo rápido y flexible para la resolución de problemas.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "What is a REPL?",
+        "title": "¿Qué es un REPL?",
         "url": "https://docs.replit.com/getting-started/intro-replit",
         "type": "article"
       },
       {
-        "title": "Code Execution AI Agent",
+        "title": "Agente de IA para Ejecución de Código",
         "url": "https://docs.praison.ai/features/codeagent",
         "type": "article"
       },
       {
-        "title": "Building an AI Agent's Code Execution Environment",
+        "title": "Construyendo un Entorno de Ejecución de Código para Agentes de IA",
         "url": "https://murraycole.com/posts/ai-code-execution-environment",
         "type": "article"
       },
       {
-        "title": "Python Code Tool",
+        "title": "Herramienta de Código Python",
         "url": "https://python.langchain.com/docs/integrations/tools/python/",
         "type": "article"
       }
     ]
   },
   "sV1BnA2-qBnXoKpUn-8Ub": {
-    "title": "Database Queries",
-    "description": "Database queries let an AI agent fetch, add, change, or remove data stored in a database. The agent sends a request written in a query language, most often SQL. The database engine then looks through its tables and returns only the rows and columns that match the rules in the request. With this tool, the agent can answer questions that need up-to-date numbers, user records, or other stored facts. It can also write new entries or adjust old ones to keep the data current. Because queries work in real time and follow clear rules, they give the agent a reliable way to handle large sets of structured information.\n\nVisit the following resources to learn more:",
+    "title": "Consultas a Bases de Datos",
+    "description": "Las consultas a bases de datos permiten a un agente de IA obtener, agregar, cambiar o eliminar datos almacenados en una base de datos. El agente envía una solicitud escrita en un lenguaje de consulta, más comúnmente SQL. El motor de la base de datos luego busca en sus tablas y devuelve solo las filas y columnas que coinciden con las reglas de la solicitud. Con esta herramienta, el agente puede responder preguntas que necesitan números actualizados, registros de usuarios u otros hechos almacenados. También puede escribir nuevas entradas o ajustar las antiguas para mantener los datos actualizados. Debido a que las consultas funcionan en tiempo real y siguen reglas claras, le dan al agente una forma confiable de manejar grandes conjuntos de información estructurada.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "Building Your Own Database Agent",
+        "title": "Construyendo tu Propio Agente de Base de Datos",
         "url": "https://www.deeplearning.ai/short-courses/building-your-own-database-agent/",
         "type": "article"
       }
     ]
   },
   "52qxjZILV-X1isup6dazC": {
-    "title": "API Requests",
-    "description": "API requests let an AI agent ask another service for data or for an action. The agent builds a short message that follows the service’s rules, sends it over the internet, and waits for a reply. For example, it can call a weather API to get today’s forecast or a payment API to charge a customer. Each request has a method like GET or POST, a URL, and often a small block of JSON with needed details. The service answers with another JSON block that the agent reads and uses. Because API requests are fast and clear, they are a common tool for connecting the agent to many other systems without extra work.\n\nVisit the following resources to learn more:",
+    "title": "Solicitudes de API",
+    "description": "Las solicitudes de API permiten a un agente de IA pedir datos o una acción a otro servicio. El agente construye un mensaje corto que sigue las reglas del servicio, lo envía por Internet y espera una respuesta. Por ejemplo, puede llamar a una API meteorológica para obtener el pronóstico de hoy o a una API de pagos para cobrar a un cliente. Cada solicitud tiene un método como GET o POST, una URL y, a menudo, un pequeño bloque de JSON con los detalles necesarios. El servicio responde con otro bloque JSON que el agente lee y utiliza. Debido a que las solicitudes de API son rápidas y claras, son una herramienta común para conectar el agente a muchos otros sistemas sin trabajo adicional.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "Introduction to APIs - MDN Web Docs",
+        "title": "Introducción a las APIs - MDN Web Docs",
         "url": "https://developer.mozilla.org/en-US/docs/Web/API/Introduction_to_APIs",
         "type": "article"
       },
       {
-        "title": "How APIs Power AI Agents: A Comprehensive Guide",
+        "title": "Cómo las APIs Impulsan a los Agentes de IA: Una Guía Completa",
         "url": "https://blog.treblle.com/api-guide-for-ai-agents/",
         "type": "article"
       }
     ]
   },
   "qaNr5I-NQPnfrRH7ynGTl": {
-    "title": "Email / Slack / SMS",
-    "description": "Email, Slack, and SMS are message channels an AI agent can use to act on tasks and share updates. The agent writes and sends emails to give detailed reports or collect files. It posts to Slack to chat with a team, answer questions, or trigger alerts inside a workspace. It sends SMS texts for quick notices such as reminders, confirmations, or warnings when a fast response is needed. By picking the right channel, the agent reaches users where they already communicate, makes sure important information arrives on time, and can even gather replies to keep a task moving forward.\n\nVisit the following resources to learn more:",
+    "title": "Correo Electrónico / Slack / SMS",
+    "description": "El correo electrónico, Slack y SMS son canales de mensajes que un agente de IA puede usar para actuar en tareas y compartir actualizaciones. El agente escribe y envía correos electrónicos para dar informes detallados o recopilar archivos. Publica en Slack para chatear con un equipo, responder preguntas o activar alertas dentro de un espacio de trabajo. Envía mensajes de texto SMS para avisos rápidos como recordatorios, confirmaciones o advertencias cuando se necesita una respuesta rápida. Al elegir el canal correcto, el agente llega a los usuarios donde ya se comunican, se asegura de que la información importante llegue a tiempo e incluso puede recopilar respuestas para mantener una tarea en movimiento.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "Twilio Messaging API",
+        "title": "API de Mensajería de Twilio",
         "url": "https://www.twilio.com/docs/usage/api",
         "type": "article"
       },
       {
-        "title": "Slack AI Agents",
+        "title": "Agentes de IA de Slack",
         "url": "https://slack.com/ai-agents",
         "type": "article"
       }
     ]
   },
   "BoJqZvdGam4cd6G6yK2IV": {
-    "title": "File System Access",
-    "description": "File system access lets an AI agent read, create, change, or delete files and folders on a computer or server. With this power, the agent can open a text file to pull data, write a new report, save logs, or tidy up old files without human help. It can also move files between folders to keep things organized. This tool is useful for tasks such as data processing, report generation, and backup jobs. Strong safety checks are needed so the agent touches only the right files, avoids private data, and cannot harm the system by mistake.\n\nVisit the following resources to learn more:",
+    "title": "Acceso al Sistema de Archivos",
+    "description": "El acceso al sistema de archivos permite a un agente de IA leer, crear, cambiar o eliminar archivos y carpetas en una computadora o servidor. Con este poder, el agente puede abrir un archivo de texto para extraer datos, escribir un nuevo informe, guardar registros o limpiar archivos antiguos sin ayuda humana. También puede mover archivos entre carpetas para mantener las cosas organizadas. Esta herramienta es útil para tareas como el procesamiento de datos, la generación de informes y los trabajos de respaldo. Se necesitan fuertes controles de seguridad para que el agente solo toque los archivos correctos, evite datos privados y no pueda dañar el sistema por error.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "Filesystem MCP server for AI Agents",
+        "title": "Servidor MCP de Sistema de Archivos para Agentes de IA",
         "url": "https://playbooks.com/mcp/mateicanavra-filesystem",
         "type": "article"
       },
       {
-        "title": "File System Access API",
+        "title": "API de Acceso al Sistema de Archivos",
         "url": "https://developer.mozilla.org/en-US/docs/Web/API/File_System_Access_API",
         "type": "article"
       },
       {
-        "title": "Understanding File Permissions and Security",
+        "title": "Comprendiendo los Permisos de Archivos y la Seguridad",
         "url": "https://linuxize.com/post/understanding-linux-file-permissions/",
         "type": "article"
       },
       {
-        "title": "How File Systems Work?",
+        "title": "¿Cómo Funcionan los Sistemas de Archivos?",
         "url": "https://www.youtube.com/watch?v=KN8YgJnShPM",
         "type": "video"
       }
     ]
   },
   "TBH_DZTAfR8Daoh-njNFC": {
-    "title": "What is Agent Memory?",
-    "description": "Agent memory is the part of an AI agent that keeps track of what has already happened. It stores past user messages, facts the agent has learned, and its own previous steps. This helps the agent remember goals, user likes and dislikes, and important details across turns or sessions. Memory can be short-term, lasting only for one conversation, or long-term, lasting across many. With a good memory the agent avoids repeating questions, stays consistent, and plans better actions. Without it, the agent would forget everything each time and feel unfocused.\n\nVisit the following resources to learn more:",
+    "title": "¿Qué es la Memoria del Agente?",
+    "description": "La memoria del agente es la parte de un agente de IA que realiza un seguimiento de lo que ya ha sucedido. Almacena mensajes de usuarios anteriores, hechos que el agente ha aprendido y sus propios pasos previos. Esto ayuda al agente a recordar objetivos, gustos y disgustos del usuario, y detalles importantes a través de turnos o sesiones. La memoria puede ser a corto plazo, durando solo una conversación, oa largo plazo, durando muchas. Con una buena memoria, el agente evita repetir preguntas, se mantiene consistente y planifica mejores acciones. Sin ella, el agente olvidaría todo cada vez y se sentiría desenfocado.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "Agentic Memory for LLM Agents",
+        "title": "Memoria Agéntica para Agentes LLM",
         "url": "https://arxiv.org/abs/2502.12110",
         "type": "article"
       },
       {
-        "title": "Memory Management in AI Agents",
+        "title": "Gestión de la Memoria en Agentes de IA",
         "url": "https://python.langchain.com/docs/how_to/chatbots_memory/",
         "type": "article"
       },
       {
-        "title": "Storing and Retrieving Knowledge for Agents",
+        "title": "Almacenamiento y Recuperación de Conocimiento para Agentes",
         "url": "https://www.pinecone.io/learn/langchain-retrieval-augmentation/",
         "type": "article"
       },
       {
-        "title": "Short-Term vs Long-Term Memory in AI Agents",
+        "title": "Memoria a Corto Plazo vs Memoria a Largo Plazo en Agentes de IA",
         "url": "https://adasci.org/short-term-vs-long-term-memory-in-ai-agents/",
         "type": "article"
       },
       {
-        "title": "Building Brain-Like Memory for AI Agents",
+        "title": "Construyendo Memoria Similar al Cerebro para Agentes de IA",
         "url": "https://www.youtube.com/watch?v=VKPngyO0iKg",
         "type": "video"
       }
     ]
   },
   "M3U6RfIqaiut2nuOibY8W": {
-    "title": "Short Term  Memory",
-    "description": "Short term memory are the facts which are passed as a part of the prompt to the LLM e.g. there might be a prompt like below:\n\n    Users Profile:\n    - name: {name}\n    - age: {age}\n    - expertise: {expertise}\n    \n    User is currently learning about {current_topic}. User has some goals in mind which are:\n    - {goal_1}\n    - {goal_2}\n    - {goal_3}\n    \n    Help the user achieve the goals.\n    \n\nNotice how we injected the user's profile, current topic and goals in the prompt. These are all short term memories.\n\nVisit the following resources to learn more:",
+    "title": "Memoria a Corto Plazo",
+    "description": "La memoria a corto plazo son los hechos que se pasan como parte del prompt al LLM, por ejemplo, podría haber un prompt como el siguiente:\n\n    Perfil del Usuario:\n    - nombre: {nombre}\n    - edad: {edad}\n    - experiencia: {experiencia}\n    \n    El usuario está aprendiendo actualmente sobre {tema_actual}. El usuario tiene algunos objetivos en mente que son:\n    - {objetivo_1}\n    - {objetivo_2}\n    - {objetivo_3}\n    \n    Ayuda al usuario a alcanzar los objetivos.\n    \n\nObserva cómo inyectamos el perfil del usuario, el tema actual y los objetivos en el prompt. Todas estas son memorias a corto plazo.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "Memory Management in AI Agents",
+        "title": "Gestión de la Memoria en Agentes de IA",
         "url": "https://python.langchain.com/docs/how_to/chatbots_memory/",
         "type": "article"
       },
       {
-        "title": "Build Smarter AI Agents: Manage Short-term and Long-term Memory",
+        "title": "Construye Agentes de IA Más Inteligentes: Gestiona la Memoria a Corto y Largo Plazo",
         "url": "https://redis.io/blog/build-smarter-ai-agents-manage-short-term-and-long-term-memory-with-redis/",
         "type": "article"
       },
       {
-        "title": "Storing and Retrieving Knowledge for Agents",
+        "title": "Almacenamiento y Recuperación de Conocimiento para Agentes",
         "url": "https://www.pinecone.io/learn/langchain-retrieval-augmentation/",
         "type": "article"
       },
       {
-        "title": "Short-Term vs Long-Term Memory in AI Agents",
+        "title": "Memoria a Corto Plazo vs Memoria a Largo Plazo en Agentes de IA",
         "url": "https://adasci.org/short-term-vs-long-term-memory-in-ai-agents/",
         "type": "article"
       },
       {
-        "title": "Building Brain-Like Memory for AI Agents",
+        "title": "Construyendo Memoria Similar al Cerebro para Agentes de IA",
         "url": "https://www.youtube.com/watch?v=VKPngyO0iKg",
         "type": "video"
       }
     ]
   },
   "Ue633fz6Xu2wa2-KOAtdP": {
-    "title": "Long Term Memory",
-    "description": "Long term memory in an AI agent stores important information for future use, like a digital notebook. It saves facts, past events, user preferences, and learned skills so the agent can make smarter and more consistent decisions over time. Unlike short-term memory, this data survives across sessions. When a similar situation comes up, the agent can look back and use what it already knows. Long term memory usually lives in a database, file system, or vector store and may hold text, numbers, embeddings, or past conversation states. Good management of long-term memory is key for building agents that feel personalized and get better with experience.\n\nVisit the following resources to learn more:",
+    "title": "Memoria a Largo Plazo",
+    "description": "La memoria a largo plazo en un agente de IA almacena información importante para uso futuro, como un cuaderno digital. Guarda hechos, eventos pasados, preferencias del usuario y habilidades aprendidas para que el agente pueda tomar decisiones más inteligentes y consistentes con el tiempo. A diferencia de la memoria a corto plazo, estos datos sobreviven a través de las sesiones. Cuando surge una situación similar, el agente puede mirar hacia atrás y usar lo que ya sabe. La memoria a largo plazo generalmente reside en una base de datos, sistema de archivos o almacén de vectores y puede contener texto, números, incrustaciones o estados de conversación pasados. Una buena gestión de la memoria a largo plazo es clave para construir agentes que se sientan personalizados y mejoren con la experiencia.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "Long Term Memory in AI Agents",
+        "title": "Memoria a Largo Plazo en Agentes de IA",
         "url": "https://medium.com/@alozie_igbokwe/ai-101-long-term-memory-in-ai-agents-35f87f2d0ce0",
         "type": "article"
       },
       {
-        "title": "Memory Management in AI Agents",
+        "title": "Gestión de la Memoria en Agentes de IA",
         "url": "https://python.langchain.com/docs/how_to/chatbots_memory/",
         "type": "article"
       },
       {
-        "title": "Storing and Retrieving Knowledge for Agents",
+        "title": "Almacenamiento y Recuperación de Conocimiento para Agentes",
         "url": "https://www.pinecone.io/learn/langchain-retrieval-augmentation/",
         "type": "article"
       },
       {
-        "title": "Short-Term vs Long-Term Memory in AI Agents",
+        "title": "Memoria a Corto Plazo vs Memoria a Largo Plazo en Agentes de IA",
         "url": "https://adasci.org/short-term-vs-long-term-memory-in-ai-agents/",
         "type": "article"
       },
       {
-        "title": "Building Brain-Like Memory for AI Agents",
+        "title": "Construyendo Memoria Similar al Cerebro para Agentes de IA",
         "url": "https://www.youtube.com/watch?v=VKPngyO0iKg",
         "type": "video"
       }
     ]
   },
   "EfCCNqLMJpWKKtamUa5gK": {
-    "title": "Episodic vs Semantic Memory",
-    "description": "Agent memory often has two parts. Episodic memory is relevant to the context of the current conversation and may be lost after the conversation ends. Semantic memory is relevant to the broader knowledge of the agent and is persistent.\n\nVisit the following resources to learn more:",
+    "title": "Memoria Episódica vs Semántica",
+    "description": "La memoria del agente a menudo tiene dos partes. La memoria episódica es relevante para el contexto de la conversación actual y puede perderse después de que finaliza la conversación. La memoria semántica es relevante para el conocimiento más amplio del agente y es persistente.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "What Is AI Agent Memory? - IBM",
+        "title": "¿Qué es la Memoria del Agente de IA? - IBM",
         "url": "https://www.ibm.com/think/topics/ai-agent-memory",
         "type": "article"
       },
       {
-        "title": "Episodic Memory vs. Semantic Memory: The Key Differences",
+        "title": "Memoria Episódica vs. Memoria Semántica: Las Diferencias Clave",
         "url": "https://www.magneticmemorymethod.com/episodic-vs-semantic-memory/",
         "type": "article"
       },
       {
-        "title": "Memory Systems in LangChain",
+        "title": "Sistemas de Memoria en LangChain",
         "url": "https://python.langchain.com/docs/how_to/chatbots_memory/",
         "type": "article"
       }
     ]
   },
   "wkS4yOJ3JdZQE_yBID8K7": {
-    "title": "RAG and Vector Databases",
-    "description": "RAG, short for Retrieval-Augmented Generation, lets an AI agent pull facts from stored data each time it answers. The data sits in a vector database. In that database, every text chunk is turned into a number list called a vector. Similar ideas create vectors that lie close together, so the agent can find related chunks fast. When the user asks a question, the agent turns the question into its own vector, finds the nearest chunks, and reads them. It then writes a reply that mixes the new prompt with those chunks. Because the data store can hold a lot of past chats, documents, or notes, this process gives the agent a working memory without stuffing everything into the prompt. It lowers token cost, keeps answers on topic, and allows the memory to grow over time.\n\nVisit the following resources to learn more:",
+    "title": "RAG y Bases de Datos Vectoriales",
+    "description": "RAG, abreviatura de Generación Aumentada por Recuperación, permite a un agente de IA extraer hechos de datos almacenados cada vez que responde. Los datos se encuentran en una base de datos vectorial. En esa base de datos, cada fragmento de texto se convierte en una lista de números llamada vector. Ideas similares crean vectores que se encuentran cerca, por lo que el agente puede encontrar fragmentos relacionados rápidamente. Cuando el usuario hace una pregunta, el agente convierte la pregunta en su propio vector, encuentra los fragmentos más cercanos y los lee. Luego escribe una respuesta que mezcla el nuevo prompt con esos fragmentos. Debido a que el almacén de datos puede contener muchos chats, documentos o notas anteriores, este proceso le da al agente una memoria funcional sin saturar todo en el prompt. Reduce el costo de los tokens, mantiene las respuestas en tema y permite que la memoria crezca con el tiempo.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "Understanding Retrieval-Augmented Generation (RAG) and Vector Databases",
+        "title": "Comprendiendo la Generación Aumentada por Recuperación (RAG) y las Bases de Datos Vectoriales",
         "url": "https://pureai.com/Articles/2025/03/03/Understanding-RAG.aspx",
         "type": "article"
       },
       {
-        "title": "Build Advanced Retrieval-Augmented Generation Systems",
+        "title": "Construye Sistemas Avanzados de Generación Aumentada por Recuperación",
         "url": "https://learn.microsoft.com/en-us/azure/developer/ai/advanced-retrieval-augmented-generation",
         "type": "article"
       },
       {
-        "title": "What Is Retrieval-Augmented Generation, aka RAG?",
+        "title": "¿Qué es la Generación Aumentada por Recuperación, también conocida como RAG?",
         "url": "https://blogs.nvidia.com/blog/what-is-retrieval-augmented-generation/",
         "type": "article"
       }
     ]
   },
   "QJqXHV8VHPTnfYfmKPzW7": {
-    "title": "User Profile Storage",
-    "description": "User profile storage is the part of an AI agent’s memory that holds stable facts about each user, such as name, age group, language, past choices, and long-term goals. The agent saves this data in a file or small database so it can load it each time the same user returns. By keeping the profile separate from short-term conversation logs, the agent can remember preferences without mixing them with temporary chat history. The profile is updated only when the user states a new lasting preference or when old information changes, which helps prevent drift or bloat.\n\nVisit the following resources to learn more:",
+    "title": "Almacenamiento de Perfiles de Usuario",
+    "description": "El almacenamiento de perfiles de usuario es la parte de la memoria de un agente de IA que contiene hechos estables sobre cada usuario, como nombre, grupo de edad, idioma, elecciones pasadas y objetivos a largo plazo. El agente guarda estos datos en un archivo o pequeña base de datos para poder cargarlos cada vez que el mismo usuario regresa. Al mantener el perfil separado de los registros de conversación a corto plazo, el agente puede recordar las preferencias sin mezclarlas con el historial de chat temporal. El perfil se actualiza solo cuando el usuario declara una nueva preferencia duradera o cuando la información antigua cambia, lo que ayuda a prevenir la desviación o la hinchazón.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "Storage Technology Explained: AI and Data Storage",
+        "title": "Tecnología de Almacenamiento Explicada: IA y Almacenamiento de Datos",
         "url": "https://www.computerweekly.com/feature/Storage-technology-explained-AI-and-the-data-storage-it-needs",
         "type": "article"
       },
       {
-        "title": "The Architect's Guide to Storage for AI - The New Stack",
+        "title": "La Guía del Arquitecto sobre Almacenamiento para IA - The New Stack",
         "url": "https://thenewstack.io/the-architects-guide-to-storage-for-ai/",
         "type": "article"
       }
     ]
   },
   "jTDC19BTWCqxqMizrIJHr": {
-    "title": "Summarization / Compression",
-    "description": "Summarization or compression lets an AI agent keep the gist of past chats without saving every line. After a talk, the agent runs a small model or rule set that pulls out key facts, goals, and feelings and writes them in a short note. This note goes into long-term memory, while the full chat can be dropped or stored elsewhere. Because the note is short, the agent spends fewer tokens when it loads memory into the next prompt, so costs stay low and speed stays high. Good summaries leave out side jokes and filler but keep names, dates, open tasks, and user preferences. The agent can update the note after each session, overwriting old points that are no longer true. This process lets the agent remember what matters even after hundreds of turns.\n\nVisit the following resources to learn more:",
+    "title": "Resumen / Compresión",
+    "description": "El resumen o la compresión permiten a un agente de IA conservar la esencia de los chats pasados sin guardar cada línea. Después de una conversación, el agente ejecuta un pequeño modelo o conjunto de reglas que extrae hechos clave, objetivos y sentimientos y los escribe en una nota breve. Esta nota va a la memoria a largo plazo, mientras que el chat completo se puede descartar o almacenar en otro lugar. Debido a que la nota es corta, el agente gasta menos tokens cuando carga la memoria en el siguiente prompt, por lo que los costos se mantienen bajos y la velocidad alta. Los buenos resúmenes omiten bromas secundarias y relleno, pero conservan nombres, fechas, tareas abiertas y preferencias del usuario. El agente puede actualizar la nota después de cada sesión, sobrescribiendo puntos antiguos que ya no son ciertos. Este proceso permite que el agente recuerde lo que importa incluso después de cientos de turnos.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "Evaluating LLMs for Text Summarization",
+        "title": "Evaluación de LLMs para Resumen de Texto",
         "url": "https://insights.sei.cmu.edu/blog/evaluating-llms-for-text-summarization-introduction/",
         "type": "article"
       },
       {
-        "title": "The Ultimate Guide to AI Document Summarization",
+        "title": "La Guía Definitiva para el Resumen de Documentos con IA",
         "url": "https://www.documentllm.com/blog/ai-document-summarization-guide",
         "type": "article"
       }
     ]
   },
   "m-97m7SI0XpBnhEE8-_1S": {
-    "title": "Forgetting / Aging Strategies",
-    "description": "Forgetting or aging strategies help an AI agent keep only the useful parts of its memory and drop the rest over time. The agent may tag each memory with a time stamp and lower its importance as it gets older, or it may remove items that have not been used for a while, much like a “least-recently-used” list. Some systems give each memory a relevance score; when space runs low, they erase the lowest-scoring items first. Others keep a fixed-length sliding window of the most recent events or create short summaries and store those instead of raw details. These methods stop the memory store from growing without limits, cut storage costs, and let the agent focus on current goals. Choosing the right mix of aging rules is a trade-off: forget too fast and the agent loses context, forget too slow and it wastes resources or reacts to outdated facts.\n\nVisit the following resources to learn more:",
+    "title": "Estrategias de Olvido / Envejecimiento",
+    "description": "Las estrategias de olvido o envejecimiento ayudan a un agente de IA a conservar solo las partes útiles de su memoria y descartar el resto con el tiempo. El agente puede etiquetar cada recuerdo con una marca de tiempo y disminuir su importancia a medida que envejece, o puede eliminar elementos que no se han utilizado durante un tiempo, de forma muy parecida a una lista de “menos recientemente utilizados”. Algunos sistemas asignan a cada recuerdo una puntuación de relevancia; cuando el espacio se agota, borran primero los elementos con la puntuación más baja. Otros mantienen una ventana deslizante de longitud fija de los eventos más recientes o crean resúmenes cortos y los almacenan en lugar de detalles sin procesar. Estos métodos evitan que el almacén de memoria crezca sin límites, reducen los costos de almacenamiento y permiten que el agente se concentre en los objetivos actuales. Elegir la combinación correcta de reglas de envejecimiento es una compensación: olvidar demasiado rápido y el agente pierde contexto, olvidar demasiado lento y desperdicia recursos o reacciona a hechos obsoletos.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "Memory Management",
+        "title": "Gestión de la Memoria",
         "url": "https://python.langchain.com/docs/how_to/chatbots_memory/",
         "type": "article"
       },
       {
-        "title": "Memory Management for AI Agents",
+        "title": "Gestión de la Memoria para Agentes de IA",
         "url": "https://techcommunity.microsoft.com/blog/azure-ai-services-blog/memory-management-for-ai-agents/4406359",
         "type": "article"
       }
     ]
   },
   "53xDks6JQ33fHMa3XcuCd": {
-    "title": "ReAct (Reason + Act)",
-    "description": "ReAct is an agent pattern that makes a model alternate between two simple steps: Reason and Act. First, the agent writes a short thought that sums up what it knows and what it should try next. Then it performs an action such as calling an API, running code, or searching a document. The result of that action is fed back, giving the agent fresh facts to think about. This loop repeats until the task is done. By showing its thoughts in plain text, the agent can be inspected, debugged, and even corrected on the fly. The clear split between thinking and doing also cuts wasted moves and guides the model toward steady progress. ReAct works well with large language models because they can both generate the chain of thoughts and choose the next tool in the very same response.\n\nVisit the following resources to learn more:",
+    "title": "ReAct (Razonar + Actuar)",
+    "description": "ReAct es un patrón de agente que hace que un modelo alterne entre dos pasos simples: Razonar y Actuar. Primero, el agente escribe un pensamiento breve que resume lo que sabe y lo que debería intentar a continuación. Luego realiza una acción como llamar a una API, ejecutar código o buscar un documento. El resultado de esa acción se retroalimenta, lo que le da al agente nuevos hechos sobre los que pensar. Este bucle se repite hasta que se completa la tarea. Al mostrar sus pensamientos en texto sin formato, el agente puede ser inspeccionado, depurado e incluso corregido sobre la marcha. La clara división entre pensar y hacer también reduce los movimientos desperdiciados y guía al modelo hacia un progreso constante. ReAct funciona bien con modelos de lenguaje grandes porque pueden generar la cadena de pensamientos y elegir la siguiente herramienta en la misma respuesta.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "ReAct: Synergizing Reasoning and Acting in Language Models",
+        "title": "ReAct: Sinergizando Razonamiento y Actuación en Modelos de Lenguaje",
         "url": "https://react-lm.github.io/",
         "type": "article"
       },
       {
-        "title": "ReAct Systems: Enhancing LLMs with Reasoning and Action",
+        "title": "Sistemas ReAct: Mejorando LLMs con Razonamiento y Acción",
         "url": "https://learnprompting.org/docs/agents/react",
         "type": "article"
       }
     ]
   },
   "1B0IqRNYdtbHDi1jHSXuI": {
-    "title": "Model Context Protocol (MCP)",
-    "description": "Model Context Protocol (MCP) is a rulebook that tells an AI agent how to pack background information before it sends a prompt to a language model. It lists what pieces go into the prompt—things like the system role, the user’s request, past memory, tool calls, or code snippets—and fixes their order. Clear tags mark each piece, so both humans and machines can see where one part ends and the next begins. Keeping the format steady cuts confusion, lets different tools work together, and makes it easier to test or swap models later. When agents follow MCP, the model gets a clean, complete prompt and can give better answers.\n\nVisit the following resources to learn more:",
+    "title": "Protocolo de Contexto del Modelo (MCP)",
+    "description": "El Protocolo de Contexto del Modelo (MCP) es un libro de reglas que le dice a un agente de IA cómo empaquetar la información de fondo antes de enviar un prompt a un modelo de lenguaje. Enumera qué piezas van en el prompt —cosas como el rol del sistema, la solicitud del usuario, la memoria pasada, las llamadas a herramientas o los fragmentos de código— y fija su orden. Etiquetas claras marcan cada pieza, para que tanto los humanos como las máquinas puedan ver dónde termina una parte y comienza la siguiente. Mantener el formato estable reduce la confusión, permite que diferentes herramientas trabajen juntas y facilita la prueba o el intercambio de modelos más tarde. Cuando los agentes siguen el MCP, el modelo recibe un prompt limpio y completo y puede dar mejores respuestas.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "Model Context Protocol",
+        "title": "Protocolo de Contexto del Modelo",
         "url": "https://github.com/modelcontextprotocol/modelcontextprotocol",
         "type": "opensource"
       },
       {
-        "title": "Model Context Protocol",
+        "title": "Protocolo de Contexto del Modelo",
         "url": "https://modelcontextprotocol.io/introduction",
         "type": "article"
       },
       {
-        "title": "Introducing the Azure MCP Server ",
+        "title": "Presentamos el Servidor MCP de Azure",
         "url": "https://devblogs.microsoft.com/azure-sdk/introducing-the-azure-mcp-server/",
         "type": "article"
       },
       {
-        "title": "The Ultimate Guide to MCP",
+        "title": "La Guía Definitiva de MCP",
         "url": "https://guangzhengli.com/blog/en/model-context-protocol",
         "type": "article"
       }
     ]
   },
   "9FryAIrWRHh8YlzKX3et5": {
-    "title": "MCP Hosts",
-    "description": "MCP Hosts are computers or services that run the Model Context Protocol. They handle incoming calls, load the MCP manifest, check requests, and pass data between users, tools, and language models. Hosts may cache recent messages, track token usage, and add safety or billing checks before sending prompts to the model. They expose an API endpoint so apps can connect easily. You can run a host on your laptop for testing or deploy it on cloud platforms for scale. The host acts as the trusted bridge where agents, tools, and data meet.\n\nVisit the following resources to learn more:",
+    "title": "Hosts MCP",
+    "description": "Los Hosts MCP son computadoras o servicios que ejecutan el Protocolo de Contexto del Modelo. Manejan las llamadas entrantes, cargan el manifiesto MCP, verifican las solicitudes y pasan datos entre usuarios, herramientas y modelos de lenguaje. Los hosts pueden almacenar en caché mensajes recientes, rastrear el uso de tokens y agregar controles de seguridad o facturación antes de enviar prompts al modelo. Exponen un punto final de API para que las aplicaciones puedan conectarse fácilmente. Puedes ejecutar un host en tu computadora portátil para realizar pruebas o implementarlo en plataformas en la nube para escalar. El host actúa como el puente confiable donde se encuentran agentes, herramientas y datos.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
         "title": "punkeye/awesome-mcp-servers",
@@ -1166,51 +1166,51 @@
         "type": "opensource"
       },
       {
-        "title": "Vercel Serverless Hosting",
+        "title": "Alojamiento Sin Servidor de Vercel",
         "url": "https://vercel.com/docs",
         "type": "article"
       },
       {
-        "title": "The Ultimate Guide to MCP",
+        "title": "La Guía Definitiva de MCP",
         "url": "https://guangzhengli.com/blog/en/model-context-protocol",
         "type": "article"
       },
       {
-        "title": "AWS MCP Servers for Code Assistants",
+        "title": "Servidores MCP de AWS para Asistentes de Código",
         "url": "https://aws.amazon.com/blogs/machine-learning/introducing-aws-mcp-servers-for-code-assistants-part-1/",
         "type": "article"
       }
     ]
   },
   "CGVstUxVXLJcYZrwk3iNQ": {
-    "title": "MCP Client",
-    "description": "The MCP Client is the part of an AI agent that talks to the language model API. It collects messages, files, and tool signals, packs them using the Model Context Protocol, and sends them to the model. When a reply comes back, it unpacks it, checks the format, and passes the result to other modules. It also tracks token usage, filters private data, retries failed calls, and logs important events for debugging.\n\nVisit the following resources to learn more:",
+    "title": "Cliente MCP",
+    "description": "El Cliente MCP es la parte de un agente de IA que habla con la API del modelo de lenguaje. Recopila mensajes, archivos y señales de herramientas, los empaqueta utilizando el Protocolo de Contexto del Modelo y los envía al modelo. Cuando llega una respuesta, la desempaqueta, comprueba el formato y pasa el resultado a otros módulos. También rastrea el uso de tokens, filtra datos privados, reintenta llamadas fallidas y registra eventos importantes para la depuración.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "Model Context Protocol",
+        "title": "Protocolo de Contexto del Modelo",
         "url": "https://github.com/modelcontextprotocol/modelcontextprotocol",
         "type": "opensource"
       },
       {
-        "title": "Model Context Protocol",
+        "title": "Protocolo de Contexto del Modelo",
         "url": "https://modelcontextprotocol.io/introduction",
         "type": "article"
       },
       {
-        "title": "OpenAI API Reference",
+        "title": "Referencia de la API de OpenAI",
         "url": "https://platform.openai.com/docs/api-reference",
         "type": "article"
       },
       {
-        "title": "Anthropic API Documentation",
+        "title": "Documentación de la API de Anthropic",
         "url": "https://docs.anthropic.com/claude/reference",
         "type": "article"
       }
     ]
   },
   "yv_-87FVM7WKn5iv6LW9q": {
-    "title": "MCP Servers",
-    "description": "An MCP Server is the main machine or cloud service that runs the Model Context Protocol. It keeps the shared “memory” that different AI agents need so they stay on the same page. When an agent sends a request, the server checks who is asking, pulls the right context from its store, and sends it back fast. It also saves new facts and task results so the next agent can use them. An MCP Server must handle many users at once, protect private data with strict access rules, and log every change for easy roll-back. Good servers break work into small tasks, spread them across many computers, and add backups so they never lose data. In short, the MCP Server is the hub that makes sure all agents share fresh, safe, and correct context.\n\nVisit the following resources to learn more:",
+    "title": "Servidores MCP",
+    "description": "Un Servidor MCP es la máquina principal o servicio en la nube que ejecuta el Protocolo de Contexto del Modelo. Mantiene la “memoria” compartida que necesitan los diferentes agentes de IA para estar en la misma página. Cuando un agente envía una solicitud, el servidor comprueba quién pregunta, extrae el contexto correcto de su almacén y lo envía rápidamente. También guarda nuevos hechos y resultados de tareas para que el próximo agente pueda usarlos. Un Servidor MCP debe manejar muchos usuarios a la vez, proteger datos privados con reglas de acceso estrictas y registrar cada cambio para facilitar la reversión. Los buenos servidores dividen el trabajo en tareas pequeñas, las distribuyen entre muchas computadoras y agregan copias de seguridad para nunca perder datos. En resumen, el Servidor MCP es el centro que asegura que todos los agentes compartan un contexto fresco, seguro y correcto.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
         "title": "punkeye/awesome-mcp-servers",
@@ -1218,290 +1218,290 @@
         "type": "opensource"
       },
       {
-        "title": "Introducing the Azure MCP Server ",
+        "title": "Presentamos el Servidor MCP de Azure",
         "url": "https://devblogs.microsoft.com/azure-sdk/introducing-the-azure-mcp-server/",
         "type": "article"
       },
       {
-        "title": "The Ultimate Guide to MCP",
+        "title": "La Guía Definitiva de MCP",
         "url": "https://guangzhengli.com/blog/en/model-context-protocol",
         "type": "article"
       },
       {
-        "title": "AWS MCP Servers for Code Assistants",
+        "title": "Servidores MCP de AWS para Asistentes de Código",
         "url": "https://aws.amazon.com/blogs/machine-learning/introducing-aws-mcp-servers-for-code-assistants-part-1/",
         "type": "article"
       }
     ]
   },
   "1NXIN-Hbjl5rPy_mqxQYW": {
-    "title": "Creating MCP Servers",
-    "description": "An MCP server stores and shares conversation data for AI agents using the Model Context Protocol (MCP), a standard for agent memory management. Start by picking a language and web framework, then create REST endpoints like `/messages`, `/state`, and `/health`. Each endpoint exchanges JSON following the MCP schema. Store session logs with a session ID, role, and timestamp using a database or in-memory store. Add token-based authentication and filters so agents can fetch only what they need. Set limits on message size and request rates to avoid overload. Finally, write unit tests, add monitoring, and run load tests to ensure stability.\n\nVisit the following resources to learn more:",
+    "title": "Creación de Servidores MCP",
+    "description": "Un servidor MCP almacena y comparte datos de conversación para agentes de IA utilizando el Protocolo de Contexto del Modelo (MCP), un estándar para la gestión de la memoria del agente. Comienza eligiendo un lenguaje y un marco web, luego crea puntos finales REST como `/messages`, `/state` y `/health`. Cada punto final intercambia JSON siguiendo el esquema MCP. Almacena los registros de sesión con un ID de sesión, rol y marca de tiempo utilizando una base de datos o un almacén en memoria. Agrega autenticación basada en tokens y filtros para que los agentes puedan obtener solo lo que necesitan. Establece límites en el tamaño de los mensajes y las tasas de solicitud para evitar la sobrecarga. Finalmente, escribe pruebas unitarias, agrega monitoreo y ejecuta pruebas de carga para garantizar la estabilidad.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "Model Context Protocol (MCP) Specification",
+        "title": "Especificación del Protocolo de Contexto del Modelo (MCP)",
         "url": "https://www.anthropic.com/news/model-context-protocol",
         "type": "article"
       },
       {
-        "title": "How to Build and Host Your Own MCP Servers in Easy Steps?",
+        "title": "¿Cómo Construir y Alojar tus Propios Servidores MCP en Pasos Sencillos?",
         "url": "https://collabnix.com/how-to-build-and-host-your-own-mcp-servers-in-easy-steps/",
         "type": "article"
       }
     ]
   },
   "iBtJp24F_kJE3YlBsW60s": {
-    "title": "Local Desktop",
-    "description": "A Local Desktop deployment means running the MCP server directly on your own computer instead of a remote cloud or server. You install the MCP software, needed runtimes, and model files onto your desktop or laptop. The server then listens on a local address like `127.0.0.1:8000`, accessible only from the same machine unless you open ports manually. This setup is great for fast tests, personal demos, or private experiments since you keep full control and avoid cloud costs. However, it's limited by your hardware's speed and memory, and others cannot access it without tunneling tools like ngrok or local port forwarding.\n\nVisit the following resources to learn more:",
+    "title": "Escritorio Local",
+    "description": "Una implementación de Escritorio Local significa ejecutar el servidor MCP directamente en tu propia computadora en lugar de una nube o servidor remoto. Instalas el software MCP, los tiempos de ejecución necesarios y los archivos del modelo en tu computadora de escritorio o portátil. Luego, el servidor escucha en una dirección local como `127.0.0.1:8000`, accesible solo desde la misma máquina a menos que abras los puertos manualmente. Esta configuración es ideal para pruebas rápidas, demostraciones personales o experimentos privados, ya que mantienes el control total y evitas los costos de la nube. Sin embargo, está limitado por la velocidad y la memoria de tu hardware, y otros no pueden acceder a él sin herramientas de tunelización como ngrok o reenvío de puertos local.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "Build a Simple Local MCP Server",
+        "title": "Construye un Servidor MCP Local Simple",
         "url": "https://blog.stackademic.com/build-simple-local-mcp-server-5434d19572a4",
         "type": "article"
       },
       {
-        "title": "How to Build and Host Your Own MCP Servers in Easy Steps",
+        "title": "Cómo Construir y Alojar tus Propios Servidores MCP en Pasos Sencillos",
         "url": "https://collabnix.com/how-to-build-and-host-your-own-mcp-servers-in-easy-steps/",
         "type": "article"
       },
       {
-        "title": "Expose localhost to Internet",
+        "title": "Expón localhost a Internet",
         "url": "https://ngrok.com/docs",
         "type": "article"
       },
       {
-        "title": "Run a Local Server on Your Machine",
+        "title": "Ejecuta un Servidor Local en tu Máquina",
         "url": "https://www.youtube.com/watch?v=ldGl6L4Vktk",
         "type": "video"
       }
     ]
   },
   "dHNMX3_t1KSDdAWqgdJXv": {
-    "title": "Remote / Cloud",
-    "description": "Remote or cloud deployment places the MCP server on a cloud provider instead of a local machine. You package the server as a container or virtual machine, choose a service like AWS, Azure, or GCP, and give it compute, storage, and a public HTTPS address. A load balancer spreads traffic, while auto-scaling adds or removes copies of the server as demand changes. You secure the endpoint with TLS, API keys, and firewalls, and you send logs and metrics to the provider’s monitoring tools. This setup lets the server handle many users, updates are easier, and you avoid local hardware limits, though you must watch costs and protect sensitive data.\n\nVisit the following resources to learn more:",
+    "title": "Remoto / Nube",
+    "description": "La implementación remota o en la nube coloca el servidor MCP en un proveedor de nube en lugar de una máquina local. Empaquetas el servidor como un contenedor o máquina virtual, eliges un servicio como AWS, Azure o GCP, y le das cómputo, almacenamiento y una dirección HTTPS pública. Un equilibrador de carga distribuye el tráfico, mientras que el autoescalado agrega o elimina copias del servidor según cambie la demanda. Aseguras el punto final con TLS, claves API y firewalls, y envías registros y métricas a las herramientas de monitoreo del proveedor. Esta configuración permite que el servidor maneje muchos usuarios, las actualizaciones son más fáciles y evitas los límites del hardware local, aunque debes vigilar los costos y proteger los datos confidenciales.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "Edge AI vs. Cloud AI: Real-Time Intelligence Models",
+        "title": "IA en el Borde vs. IA en la Nube: Modelos de Inteligencia en Tiempo Real",
         "url": "https://medium.com/@hassaanidrees7/edge-ai-vs-cloud-ai-real-time-intelligence-vs-centralized-processing-df8c6e94fd11",
         "type": "article"
       },
       {
-        "title": "Cloud AI vs. On-premises AI",
+        "title": "IA en la Nube vs. IA Local",
         "url": "https://www.pluralsight.com/resources/blog/ai-and-data/ai-on-premises-vs-in-cloud",
         "type": "article"
       },
       {
-        "title": "Cloud vs On-Premises AI Deployment",
+        "title": "Implementación de IA en la Nube vs Local",
         "url": "https://toxigon.com/cloud-vs-on-premises-ai-deployment",
         "type": "article"
       }
     ]
   },
   "qwdh5pkBbrF8LKPxbZp4F": {
-    "title": "Chain of Thought (CoT)",
-    "description": "Chain of Thought (CoT) is a way for an AI agent to think out loud. Before giving its final answer, the agent writes short notes that show each step it takes. These notes can list facts, name sub-tasks, or do small bits of math. By seeing the steps, the agent stays organized and is less likely to make a mistake. People who read the answer can also check the logic and spot any weak points. The same written steps can be fed back into the agent so it can plan, reflect, or fix itself. Because it is easy to use and boosts trust, CoT is one of the most common designs for language-based agents today.\n\nVisit the following resources to learn more:",
+    "title": "Cadena de Pensamiento (CoT)",
+    "description": "La Cadena de Pensamiento (CoT) es una forma en que un agente de IA piensa en voz alta. Antes de dar su respuesta final, el agente escribe notas breves que muestran cada paso que toma. Estas notas pueden enumerar hechos, nombrar subtareas o realizar pequeños cálculos matemáticos. Al ver los pasos, el agente se mantiene organizado y es menos probable que cometa un error. Las personas que leen la respuesta también pueden verificar la lógica y detectar cualquier punto débil. Los mismos pasos escritos se pueden retroalimentar al agente para que pueda planificar, reflexionar o corregirse a sí mismo. Debido a que es fácil de usar y aumenta la confianza, CoT es uno de los diseños más comunes para los agentes basados en lenguaje en la actualidad.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "Chain-of-Thought Prompting Elicits Reasoning in Large Language Models",
+        "title": "El Prompting de Cadena de Pensamiento Suscita el Razonamiento en Modelos de Lenguaje Grandes",
         "url": "https://arxiv.org/abs/2201.11903",
         "type": "article"
       },
       {
-        "title": "Evoking Chain of Thought Reasoning in LLMs - Prompting Guide",
+        "title": "Evocando el Razonamiento de Cadena de Pensamiento en LLMs - Guía de Prompting",
         "url": "https://www.promptingguide.ai/techniques/cot",
         "type": "article"
       }
     ]
   },
   "cW8O4vLLKEG-Q0dE8E5Zp": {
-    "title": "RAG Agent",
-    "description": "A RAG (Retrieval-Augmented Generation) agent mixes search with language generation so it can answer questions using fresh and reliable facts. When a user sends a query, the agent first turns that query into an embedding—basically a number list that captures its meaning. It then looks up similar embeddings in a vector database that holds passages from web pages, PDFs, or other text. The best-matching passages come back as context. The agent puts the original question and those passages into a large language model. The model writes the final reply, grounding every sentence in the retrieved text. This setup keeps the model smaller, reduces wrong guesses, and lets the system update its knowledge just by adding new documents to the database. Common tools for building a RAG agent include an embedding model, a vector store like FAISS or Pinecone, and an LLM connected through a framework such as LangChain or LlamaIndex.\n\nVisit the following resources to learn more:",
+    "title": "Agente RAG",
+    "description": "Un agente RAG (Generación Aumentada por Recuperación) mezcla la búsqueda con la generación de lenguaje para poder responder preguntas utilizando hechos frescos y confiables. Cuando un usuario envía una consulta, el agente primero convierte esa consulta en una incrustación, básicamente una lista de números que captura su significado. Luego busca incrustaciones similares en una base de datos vectorial que contiene pasajes de páginas web, PDF u otro texto. Los pasajes que mejor coinciden regresan como contexto. El agente coloca la pregunta original y esos pasajes en un modelo de lenguaje grande. El modelo escribe la respuesta final, basando cada oración en el texto recuperado. Esta configuración mantiene el modelo más pequeño, reduce las conjeturas incorrectas y permite que el sistema actualice su conocimiento simplemente agregando nuevos documentos a la base de datos. Las herramientas comunes para construir un agente RAG incluyen un modelo de incrustación, un almacén de vectores como FAISS o Pinecone, y un LLM conectado a través de un marco como LangChain o LlamaIndex.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "What is RAG? - Retrieval-Augmented Generation AI Explained",
+        "title": "¿Qué es RAG? - Explicación de la IA de Generación Aumentada por Recuperación",
         "url": "https://aws.amazon.com/what-is/retrieval-augmented-generation/",
         "type": "article"
       },
       {
-        "title": "What Is Retrieval-Augmented Generation, aka RAG?",
+        "title": "¿Qué es la Generación Aumentada por Recuperación, también conocida como RAG?",
         "url": "https://blogs.nvidia.com/blog/what-is-retrieval-augmented-generation/",
         "type": "article"
       }
     ]
   },
   "6YLCMWzystao6byCYCTPO": {
-    "title": "Planner Executor",
-    "description": "A **planner-executor agent** is a type of AI agent that splits its work into two clear parts: planning and execution. The **planner** thinks ahead, taking a goal and breaking it down into a sequence of steps, ordering them in a logical and efficient manner. The **executor**, on the other hand, takes each planned step and carries it out, monitoring the results and reporting back to the planner. If something fails or the world changes, the planner may update the plan, and the executor follows the new steps. This modular approach allows the agent to handle complex tasks by dividing them into manageable parts, making it easier to debug, reuse plans, and maintain clear and consistent behavior.\n\nVisit the following resources to learn more:",
+    "title": "Planificador Ejecutor",
+    "description": "Un **agente planificador-ejecutor** es un tipo de agente de IA que divide su trabajo en dos partes claras: planificación y ejecución. El **planificador** piensa con anticipación, tomando un objetivo y dividiéndolo en una secuencia de pasos, ordenándolos de manera lógica y eficiente. El **ejecutor**, por otro lado, toma cada paso planificado y lo lleva a cabo, monitoreando los resultados e informando al planificador. Si algo falla o el mundo cambia, el planificador puede actualizar el plan y el ejecutor sigue los nuevos pasos. Este enfoque modular permite al agente manejar tareas complejas dividiéndolas en partes manejables, lo que facilita la depuración, la reutilización de planes y el mantenimiento de un comportamiento claro y consistente.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "Plan-and-Execute Agents",
+        "title": "Agentes de Planificación y Ejecución",
         "url": "https://blog.langchain.dev/planning-agents/",
         "type": "article"
       },
       {
-        "title": "Plan and Execute: AI Agents Architecture",
+        "title": "Planificar y Ejecutar: Arquitectura de Agentes de IA",
         "url": "https://medium.com/@shubham.ksingh.cer14/plan-and-execute-ai-agents-architecture-f6c60b5b9598",
         "type": "article"
       }
     ]
   },
   "Ep8RoZSy_Iq_zWXlGQLZo": {
-    "title": "DAG Agents",
-    "description": "A DAG (Directed Acyclic Graph) agent is made of small parts called nodes that form a one-way graph with no loops. Each node does a task and passes its result to the next. Because there are no cycles, data always moves forward, making workflows easy to follow and debug. Independent nodes can run in parallel, speeding up tasks. If a node fails, you can trace and fix that part without touching the rest. DAG agents are ideal for jobs like data cleaning, multi-step reasoning, or workflows where backtracking isn’t needed.\n\nVisit the following resources to learn more:",
+    "title": "Agentes DAG",
+    "description": "Un agente DAG (Grafo Acíclico Dirigido) está hecho de pequeñas partes llamadas nodos que forman un grafo unidireccional sin bucles. Cada nodo realiza una tarea y pasa su resultado al siguiente. Como no hay ciclos, los datos siempre avanzan, lo que facilita el seguimiento y la depuración de los flujos de trabajo. Los nodos independientes pueden ejecutarse en paralelo, acelerando las tareas. Si un nodo falla, puedes rastrear y corregir esa parte sin tocar el resto. Los agentes DAG son ideales para trabajos como la limpieza de datos, el razonamiento de varios pasos o los flujos de trabajo donde no se necesita retroceder.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "Airflow: Directed Acyclic Graphs Documentation",
+        "title": "Airflow: Documentación de Grafos Acíclicos Dirigidos",
         "url": "https://airflow.apache.org/docs/apache-airflow/stable/concepts/dags.html",
         "type": "article"
       },
       {
-        "title": "What are DAGs in AI Systems?",
+        "title": "¿Qué son los DAGs en los Sistemas de IA?",
         "url": "https://www.restack.io/p/version-control-for-ai-answer-what-is-dag-in-ai-cat-ai",
         "type": "article"
       },
       {
-        "title": "DAGs Explained Simply",
+        "title": "DAGs Explicados de Forma Sencilla",
         "url": "https://www.youtube.com/watch?v=1Yh5S-S6wsI",
         "type": "video"
       }
     ]
   },
   "Nmy1PoB32DcWZnPM8l8jT": {
-    "title": "Tree-of-Thought",
-    "description": "Tree-of-Thought is a way to organize an AI agent’s reasoning as a branching tree. At the root, the agent states the main problem. Each branch is a small idea, step, or guess that could lead to a solution. The agent expands the most promising branches, checks if they make sense, and prunes paths that look wrong or unhelpful. This setup helps the agent explore many possible answers while staying focused on the best ones. Because the agent can compare different branches side by side, it is less likely to get stuck on a bad line of thought. The result is more reliable and creative problem solving.\n\nVisit the following resources to learn more:",
+    "title": "Árbol del Pensamiento",
+    "description": "El Árbol del Pensamiento es una forma de organizar el razonamiento de un agente de IA como un árbol ramificado. En la raíz, el agente enuncia el problema principal. Cada rama es una pequeña idea, paso o suposición que podría conducir a una solución. El agente expande las ramas más prometedoras, comprueba si tienen sentido y poda los caminos que parecen incorrectos o inútiles. Esta configuración ayuda al agente a explorar muchas respuestas posibles mientras se mantiene enfocado en las mejores. Como el agente puede comparar diferentes ramas lado a lado, es menos probable que se atasque en una mala línea de pensamiento. El resultado es una resolución de problemas más confiable y creativa.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "Tree of Thoughts (ToT) | Prompt Engineering Guide",
+        "title": "Árbol de Pensamientos (ToT) | Guía de Ingeniería de Prompts",
         "url": "https://www.promptingguide.ai/techniques/tot",
         "type": "article"
       },
       {
-        "title": "What is tree-of-thoughts? - IBM",
+        "title": "¿Qué es el árbol de pensamientos? - IBM",
         "url": "https://www.ibm.com/think/topics/tree-of-thoughts",
         "type": "article"
       },
       {
-        "title": "The Revolutionary Approach of Tree-of-Thought Prompting in AI",
+        "title": "El Enfoque Revolucionario del Prompting de Árbol de Pensamiento en IA",
         "url": "https://medium.com/@WeavePlatform/the-revolutionary-approach-of-tree-of-thought-prompting-in-ai-eb7c0872247b",
         "type": "article"
       }
     ]
   },
   "US6T5dXM8IY9V2qZnTOFW": {
-    "title": "Manual (from scratch)",
-    "description": "Building an AI agent from scratch means writing every part of the system yourself, without ready-made libraries. You define how the agent senses inputs, stores memory, makes decisions, and learns over time. First, you pick a clear goal, like solving puzzles or chatting. Then you code the inputs (keyboard, mouse, text), decision logic (rules or neural networks), and memory (saving facts from past events). Testing is critical: you run the agent, watch its actions, debug, and improve. Though it takes longer, this approach gives deep understanding and full control over how the agent works and evolves.\n\nVisit the following resources to learn more:",
+    "title": "Manual (desde cero)",
+    "description": "Construir un agente de IA desde cero significa escribir cada parte del sistema tú mismo, sin bibliotecas prefabricadas. Defines cómo el agente percibe las entradas, almacena la memoria, toma decisiones y aprende con el tiempo. Primero, eliges un objetivo claro, como resolver acertijos o chatear. Luego codificas las entradas (teclado, mouse, texto), la lógica de decisión (reglas o redes neuronales) y la memoria (guardando hechos de eventos pasados). Las pruebas son críticas: ejecutas el agente, observas sus acciones, depuras y mejoras. Aunque lleva más tiempo, este enfoque brinda una comprensión profunda y un control total sobre cómo funciona y evoluciona el agente.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "A Step-by-Step Guide to Building an AI Agent From Scratch",
+        "title": "Una Guía Paso a Paso para Construir un Agente de IA Desde Cero",
         "url": "https://www.neurond.com/blog/how-to-build-an-ai-agent",
         "type": "article"
       },
       {
-        "title": "How to Build AI Agents",
+        "title": "Cómo Construir Agentes de IA",
         "url": "https://wotnot.io/blog/build-ai-agents",
         "type": "article"
       },
       {
-        "title": "Build Your Own AI Agent from Scratch in 30 Minutes",
+        "title": "Construye tu Propio Agente de IA desde Cero en 30 Minutos",
         "url": "https://medium.com/@gurpartap.sandhu3/build-you-own-ai-agent-from-scratch-in-30-mins-using-simple-python-1458f8099da0",
         "type": "article"
       },
       {
-        "title": "Building an AI Agent From Scratch",
+        "title": "Construyendo un Agente de IA Desde Cero",
         "url": "https://www.youtube.com/watch?v=bTMPwUgLZf0",
         "type": "video"
       }
     ]
   },
   "aafZxtjxiwzJH1lwHBODi": {
-    "title": "LLM Native \"Function Calling\"",
-    "description": "LLM native “function calling” lets a large language model decide when to run a piece of code and which inputs to pass to it. You first tell the model what functions are available. For each one you give a short name, a short description, and a list of arguments with their types. During a chat, the model can answer in JSON that matches this schema instead of plain text. Your wrapper program reads the JSON, calls the real function, and then feeds the result back to the model so it can keep going. This loop helps an agent search the web, look up data, send an email, or do any other task you expose. Because the output is structured, you get fewer mistakes than when the model tries to write raw code or natural-language commands.\n\nVisit the following resources to learn more:",
+    "title": "LLM Nativo \"Llamada de Función\"",
+    "description": "La “llamada de función” nativa de LLM permite que un modelo de lenguaje grande decida cuándo ejecutar un fragmento de código y qué entradas pasarle. Primero le dices al modelo qué funciones están disponibles. Para cada una, das un nombre corto, una descripción breve y una lista de argumentos con sus tipos. Durante un chat, el modelo puede responder en JSON que coincida con este esquema en lugar de texto sin formato. Tu programa contenedor lee el JSON, llama a la función real y luego retroalimenta el resultado al modelo para que pueda continuar. Este bucle ayuda a un agente a buscar en la web, buscar datos, enviar un correo electrónico o realizar cualquier otra tarea que expongas. Debido a que la salida está estructurada, obtienes menos errores que cuando el modelo intenta escribir código sin procesar o comandos en lenguaje natural.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "A Comprehensive Guide to Function Calling in LLMs",
+        "title": "Una Guía Completa para la Llamada de Funciones en LLMs",
         "url": "https://thenewstack.io/a-comprehensive-guide-to-function-calling-in-llms/",
         "type": "article"
       },
       {
-        "title": "Function Calling with LLMs | Prompt Engineering Guide",
+        "title": "Llamada de Funciones con LLMs | Guía de Ingeniería de Prompts",
         "url": "https://www.promptingguide.ai/applications/function_calling",
         "type": "article"
       },
       {
-        "title": "Function Calling with Open-Source LLMs",
+        "title": "Llamada de Funciones con LLMs de Código Abierto",
         "url": "https://medium.com/@rushing_andrei/function-calling-with-open-source-llms-594aa5b3a304",
         "type": "article"
       }
     ]
   },
   "AQtxTTxmBpfl8BMgJbGzc": {
-    "title": "OpenAI Functions Calling",
-    "description": "OpenAI Function Calling lets you give a language model a list of tools and have it decide which one to use and with what data. You describe each tool with a short name, what it does, and the shape of its inputs in a small JSON-like schema. You then pass the user message and this tool list to the model. Instead of normal text, the model can reply with a JSON block that names the tool and fills in the needed arguments. Your program reads this block, runs the real function, and can send the result back for the next step. This pattern makes agent actions clear, easy to parse, and hard to abuse, because the model cannot run code on its own and all calls go through your checks. It also cuts down on prompt hacks and wrong formats, so agents work faster and more safely.\n\nVisit the following resources to learn more:",
+    "title": "Llamada de Funciones de OpenAI",
+    "description": "La Llamada de Funciones de OpenAI te permite darle a un modelo de lenguaje una lista de herramientas y hacer que decida cuál usar y con qué datos. Describes cada herramienta con un nombre corto, qué hace y la forma de sus entradas en un pequeño esquema similar a JSON. Luego pasas el mensaje del usuario y esta lista de herramientas al modelo. En lugar de texto normal, el modelo puede responder con un bloque JSON que nombra la herramienta y completa los argumentos necesarios. Tu programa lee este bloque, ejecuta la función real y puede enviar el resultado de vuelta para el siguiente paso. Este patrón hace que las acciones del agente sean claras, fáciles de analizar y difíciles de abusar, porque el modelo no puede ejecutar código por sí solo y todas las llamadas pasan por tus controles. También reduce los hacks de prompts y los formatos incorrectos, por lo que los agentes funcionan más rápido y de forma más segura.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "OpenAI Documentation – Function Calling",
+        "title": "Documentación de OpenAI – Llamada de Funciones",
         "url": "https://platform.openai.com/docs/guides/function-calling",
         "type": "article"
       },
       {
-        "title": "OpenAI Cookbook – Using Functions with GPT Models",
+        "title": "Libro de Recetas de OpenAI – Uso de Funciones con Modelos GPT",
         "url": "https://github.com/openai/openai-cookbook/blob/main/examples/How_to_call_functions_with_chat_models.ipynb",
         "type": "article"
       },
       {
-        "title": "@officialOpenAI Blog – Announcing Function Calling and Other Updates",
+        "title": "Blog de @officialOpenAI – Anuncio de Llamada de Funciones y Otras Actualizaciones",
         "url": "https://openai.com/blog/function-calling-and-other-api-updates",
         "type": "article"
       },
       {
-        "title": "@officialOpenAI API Reference – Functions Section",
+        "title": "Referencia de la API de @officialOpenAI – Sección de Funciones",
         "url": "https://platform.openai.com/docs/api-reference/chat/create#functions",
         "type": "article"
       },
       {
-        "title": "@officialOpenAI Community – Discussions and Examples on Function Calling",
+        "title": "Comunidad de @officialOpenAI – Discusiones y Ejemplos sobre Llamada de Funciones",
         "url": "https://community.openai.com/tag/function-calling",
         "type": "article"
       }
     ]
   },
   "_iIsBJTVS6OBf_dsdmbVO": {
-    "title": "Gemini Function Calling",
-    "description": "Gemini function calling lets you hook the Gemini language model to real code in a safe and simple way. You first list the functions you want it to use, each with a name, a short note about what it does, and a JSON schema for the needed arguments. When the user speaks, Gemini checks this list and, if a match makes sense, answers with a tiny JSON block that holds the chosen function name and the filled-in arguments. Your program then runs that function, sends the result back, and the chat moves on. Because the reply is strict JSON and not free text, you do not have to guess at what the model means, and you avoid many errors. This flow lets you build agents that pull data, call APIs, or carry out long action chains while keeping control of business logic on your side.\n\nVisit the following resources to learn more:",
+    "title": "Llamada de Función de Gemini",
+    "description": "La llamada de función de Gemini te permite conectar el modelo de lenguaje Gemini a código real de una manera segura y sencilla. Primero listas las funciones que quieres que use, cada una con un nombre, una nota breve sobre lo que hace y un esquema JSON para los argumentos necesarios. Cuando el usuario habla, Gemini revisa esta lista y, si una coincidencia tiene sentido, responde con un pequeño bloque JSON que contiene el nombre de la función elegida y los argumentos completados. Tu programa luego ejecuta esa función, envía el resultado de vuelta y el chat continúa. Debido a que la respuesta es JSON estricto y no texto libre, no tienes que adivinar lo que el modelo quiere decir y evitas muchos errores. Este flujo te permite construir agentes que extraen datos, llaman a API o llevan a cabo largas cadenas de acciones mientras mantienes el control de la lógica de negocio de tu lado.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "Function Calling with the Gemini API",
+        "title": "Llamada de Función con la API de Gemini",
         "url": "https://ai.google.dev/gemini-api/docs/function-calling",
         "type": "article"
       },
       {
-        "title": "Understanding Function Calling in Gemini",
+        "title": "Comprendiendo la Llamada de Función в Gemini",
         "url": "https://medium.com/google-cloud/understanding-function-calling-in-gemini-3097937f1905",
         "type": "article"
       }
     ]
   },
   "37GBFVZ2J2d5r8bd1ViHq": {
-    "title": "OpenAI Assistant API",
-    "description": "The OpenAI Assistants API lets you add clear, task-specific actions to a chat with a large language model. You first describe each action you want the model to use, giving it a name, a short purpose, and a list of inputs in JSON form. During the chat, the model may decide that one of these actions will help. It then returns the name of the action and a JSON object with the input values it thinks are right. Your code receives this call, runs real work such as a database query or a web request, and sends the result back to the model. The model reads the result and continues the chat, now armed with fresh facts. This loop lets you keep control of what real work happens while still letting the model plan and talk in natural language.\n\nVisit the following resources to learn more:",
+    "title": "API de Asistentes de OpenAI",
+    "description": "La API de Asistentes de OpenAI te permite agregar acciones claras y específicas de la tarea a un chat con un modelo de lenguaje grande. Primero describes cada acción que quieres que el modelo use, dándole un nombre, un propósito breve y una lista de entradas en formato JSON. Durante el chat, el modelo puede decidir que una de estas acciones ayudará. Luego devuelve el nombre de la acción y un objeto JSON con los valores de entrada que cree correctos. Tu código recibe esta llamada, ejecuta trabajo real como una consulta de base de datos o una solicitud web, y envía el resultado de vuelta al modelo. El modelo lee el resultado y continúa el chat, ahora armado con hechos frescos. Este bucle te permite mantener el control de qué trabajo real sucede mientras sigues dejando que el modelo planifique y hable en lenguaje natural.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "OpenAI Documentation – Assistants API Overview",
+        "title": "Documentación de OpenAI – Descripción General de la API de Asistentes",
         "url": "https://platform.openai.com/docs/assistants/overview",
         "type": "article"
       },
       {
-        "title": "OpenAI Blog – Introducing the Assistants API",
+        "title": "Blog de OpenAI – Presentación de la API de Asistentes",
         "url": "https://openai.com/blog/assistants-api",
         "type": "article"
       },
       {
-        "title": "OpenAI Cookbook – Assistants API Example",
+        "title": "Libro de Recetas de OpenAI – Ejemplo de la API de Asistentes",
         "url": "https://github.com/openai/openai-cookbook/blob/main/examples/Assistants_API_overview_python.ipynb",
         "type": "article"
       },
       {
-        "title": "OpenAI API Reference – Assistants Endpoints",
+        "title": "Referencia de la API de OpenAI – Puntos Finales de Asistentes",
         "url": "https://platform.openai.com/docs/api-reference/assistants",
         "type": "article"
       }
@@ -1509,7 +1509,7 @@
   },
   "Ka6VpCEnqABvwiF9vba7t": {
     "title": "Langchain",
-    "description": "LangChain is a Python and JavaScript library that helps you put large language models to work in real products. It gives ready-made parts for common agent tasks such as talking to many tools, keeping short-term memory, and calling an external API when the model needs fresh data. You combine these parts like Lego blocks: pick a model, add a prompt template, chain the steps, then wrap the chain in an “agent” that can choose what step to run next. Built-in connectors link to OpenAI, Hugging Face, vector stores, and SQL databases, so you can search documents or pull company data without writing a lot of glue code. This lets you move fast from idea to working bot, while still letting you swap out parts if your needs change.\n\nVisit the following resources to learn more:",
+    "description": "LangChain es una biblioteca de Python y JavaScript que te ayuda a poner a trabajar modelos de lenguaje grandes en productos reales. Proporciona partes listas para usar para tareas comunes de agentes, como hablar con muchas herramientas, mantener memoria a corto plazo y llamar a una API externa cuando el modelo necesita datos frescos. Combinas estas partes como bloques de Lego: eliges un modelo, agregas una plantilla de prompt, encadenas los pasos y luego envuelves la cadena en un “agente” que puede elegir qué paso ejecutar a continuación. Los conectores incorporados se vinculan a OpenAI, Hugging Face, almacenes de vectores y bases de datos SQL, para que puedas buscar documentos o extraer datos de la empresa sin escribir mucho código de unión. Esto te permite pasar rápidamente de la idea al bot funcional, sin dejar de permitirte intercambiar partes si tus necesidades cambian.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
         "title": "langchain-ai/langchain",
@@ -1517,22 +1517,22 @@
         "type": "opensource"
       },
       {
-        "title": "LangChain Documentation",
+        "title": "Documentación de LangChain",
         "url": "https://python.langchain.com/docs/introduction/",
         "type": "article"
       },
       {
-        "title": "Building Applications with LLMs using LangChain",
+        "title": "Construyendo Aplicaciones con LLMs usando LangChain",
         "url": "https://www.pinecone.io/learn/series/langchain/",
         "type": "article"
       },
       {
-        "title": "AI Agents with LangChain and LangGraph",
+        "title": "Agentes de IA con LangChain y LangGraph",
         "url": "https://www.udacity.com/course/ai-agents-with-langchain-and-langgraph--cd13764",
         "type": "article"
       },
       {
-        "title": "LangChain Crash Course - Build LLM Apps Fast (YouTube)",
+        "title": "Curso Intensivo de LangChain - Construye Aplicaciones LLM Rápidamente (YouTube)",
         "url": "https://www.youtube.com/watch?v=nAmC7SoVLd8",
         "type": "video"
       }
@@ -1540,7 +1540,7 @@
   },
   "iEHF-Jm3ck-Iu85EbCoDi": {
     "title": "LlamaIndex",
-    "description": "LlamaIndex is an open-source Python toolkit that helps you give a language model access to your own data. You load files such as PDFs, web pages, or database rows. The toolkit breaks the text into chunks, turns them into vectors, and stores them in a chosen vector store like FAISS or Pinecone. When a user asks a question, LlamaIndex finds the best chunks, adds them to the prompt, and sends the prompt to the model. This flow is called retrieval-augmented generation and it lets an agent give answers grounded in your content. The library offers simple classes for loading, indexing, querying, and composing tools, so you write less boilerplate code. It also works with other frameworks, including LangChain, and supports models from OpenAI or Hugging Face. With a few lines of code you can build a chatbot, Q&A system, or other agent that knows your documents.\n\nVisit the following resources to learn more:",
+    "description": "LlamaIndex es un conjunto de herramientas de Python de código abierto que te ayuda a dar acceso a un modelo de lenguaje a tus propios datos. Cargas archivos como PDF, páginas web o filas de bases de datos. El conjunto de herramientas divide el texto en fragmentos, los convierte en vectores y los almacena en un almacén de vectores elegido como FAISS o Pinecone. Cuando un usuario hace una pregunta, LlamaIndex encuentra los mejores fragmentos, los agrega al prompt y envía el prompt al modelo. Este flujo se llama generación aumentada por recuperación y permite que un agente dé respuestas basadas en tu contenido. La biblioteca ofrece clases simples para cargar, indexar, consultar y componer herramientas, por lo que escribes menos código repetitivo. También funciona con otros marcos, incluido LangChain, y admite modelos de OpenAI o Hugging Face. Con unas pocas líneas de código puedes construir un chatbot, un sistema de preguntas y respuestas u otro agente que conozca tus documentos.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
         "title": "run-llama/llama_index",
@@ -1553,17 +1553,17 @@
         "type": "article"
       },
       {
-        "title": "LlamaIndex Documentation",
+        "title": "Documentación de LlamaIndex",
         "url": "https://docs.smith.langchain.com/",
         "type": "article"
       },
       {
-        "title": "What is LlamaIndex.TS",
+        "title": "¿Qué es LlamaIndex.TS?",
         "url": "https://ts.llamaindex.ai/docs/llamaindex",
         "type": "article"
       },
       {
-        "title": "What is LlamaIndex? - IBM",
+        "title": "¿Qué es LlamaIndex? - IBM",
         "url": "https://www.ibm.com/think/topics/llamaindex",
         "type": "article"
       },
@@ -1576,7 +1576,7 @@
   },
   "XS-FsvtrXGZ8DPrwOsnlI": {
     "title": "Haystack",
-    "description": "Haystack is an open-source Python framework that helps you build search and question-answering agents fast. You connect your data sources, pick a language model, and set up pipelines that find the best answer to a user’s query. Haystack handles tasks such as indexing documents, retrieving passages, running the model, and ranking results. It works with many back-ends like Elasticsearch, OpenSearch, FAISS, and Pinecone, so you can scale from a laptop to a cluster. You can add features like summarization, translation, and document chat by dropping extra nodes into the pipeline. The framework also offers REST APIs, a web UI, and clear tutorials, making it easy to test and deploy your agent in production.\n\nVisit the following resources to learn more:",
+    "description": "Haystack es un marco de Python de código abierto que te ayuda a construir rápidamente agentes de búsqueda y respuesta a preguntas. Conectas tus fuentes de datos, eliges un modelo de lenguaje y configuras canalizaciones que encuentran la mejor respuesta a la consulta de un usuario. Haystack maneja tareas como la indexación de documentos, la recuperación de pasajes, la ejecución del modelo y la clasificación de resultados. Funciona con muchos back-ends como Elasticsearch, OpenSearch, FAISS y Pinecone, por lo que puedes escalar desde una computadora portátil hasta un clúster. Puedes agregar funciones como resumen, traducción y chat de documentos agregando nodos adicionales a la canalización. El marco también ofrece API REST, una interfaz de usuario web y tutoriales claros, lo que facilita la prueba e implementación de tu agente en producción.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
         "title": "deepset-ai/haystack",
@@ -1589,7 +1589,7 @@
         "type": "article"
       },
       {
-        "title": "Haystack Overview",
+        "title": "Descripción General de Haystack",
         "url": "https://docs.haystack.deepset.ai/docs/intro",
         "type": "article"
       }
@@ -1597,7 +1597,7 @@
   },
   "7YtnQ9-KIvGPSpDzEDexl": {
     "title": "AutoGen",
-    "description": "AutoGen is an open-source Python framework that helps you build AI agents without starting from scratch. It lets you define each agent with a role, goals, and tools, then handles the chat flow between them and a large language model such as GPT-4. You can chain several agents so they plan, code, review, and run tasks together. The library includes ready-made modules for memory, task planning, tool calling, and function execution, so you only write the parts that are unique to your app. AutoGen connects to OpenAI, Azure, or local models through a simple settings file. Logs, cost tracking, and step-by-step debugging come built in, which makes testing easy. Because the agents are plain Python objects, you can mix them with other libraries or your own code. AutoGen is still young, so expect fast changes and keep an eye on usage costs, but it is a strong choice when you want to turn a prompt into a working multi-agent system in hours instead of weeks.\n\nVisit the following resources to learn more:",
+    "description": "AutoGen es un marco de Python de código abierto que te ayuda a construir agentes de IA sin empezar desde cero. Te permite definir cada agente con un rol, objetivos y herramientas, luego maneja el flujo de chat entre ellos y un modelo de lenguaje grande como GPT-4. Puedes encadenar varios agentes para que planifiquen, codifiquen, revisen y ejecuten tareas juntos. La biblioteca incluye módulos listos para usar para memoria, planificación de tareas, llamada a herramientas y ejecución de funciones, por lo que solo escribes las partes que son únicas para tu aplicación. AutoGen se conecta a OpenAI, Azure o modelos locales a través de un archivo de configuración simple. Los registros, el seguimiento de costos y la depuración paso a paso vienen incorporados, lo que facilita las pruebas. Debido a que los agentes son objetos simples de Python, puedes mezclarlos con otras bibliotecas o tu propio código. AutoGen aún es joven, así que espera cambios rápidos y mantén un ojo en los costos de uso, pero es una opción sólida cuando quieres convertir un prompt en un sistema multiagente funcional en horas en lugar de semanas.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
         "title": "GitHub - microsoft/autogen",
@@ -1613,7 +1613,7 @@
   },
   "uFPJqgU4qGvZyxTv-osZA": {
     "title": "CrewAI",
-    "description": "CrewAI is an open-source Python framework for creating teams of AI agents, called a crew. Each agent is assigned a name, role, and set of tools, and the system manages planning, communication, and execution between them. To use it, install the package, define agents in code, connect them with a `Crew` object, and assign a mission prompt. CrewAI interacts with an LLM like GPT-4 or Claude, passes messages, runs tools, and returns a final output. You can also add web search, custom functions, or memory stores. Logs are built-in to help debug and optimize workflows.\n\nVisit the following resources to learn more:",
+    "description": "CrewAI es un marco de Python de código abierto para crear equipos de agentes de IA, llamados una cuadrilla. A cada agente se le asigna un nombre, un rol y un conjunto de herramientas, y el sistema gestiona la planificación, la comunicación y la ejecución entre ellos. Para usarlo, instala el paquete, define los agentes en el código, conéctalos con un objeto `Crew` y asigna un prompt de misión. CrewAI interactúa con un LLM como GPT-4 o Claude, pasa mensajes, ejecuta herramientas y devuelve una salida final. También puedes agregar búsqueda web, funciones personalizadas o almacenes de memoria. Los registros están incorporados para ayudar a depurar y optimizar los flujos de trabajo.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
         "title": "CrewAI",
@@ -1621,17 +1621,17 @@
         "type": "article"
       },
       {
-        "title": "CrewAI Documentation",
+        "title": "Documentación de CrewAI",
         "url": "https://docs.crewai.com/",
         "type": "article"
       },
       {
-        "title": "Getting Started with CrewAI: Building AI Agents That Work Together",
+        "title": "Primeros Pasos con CrewAI: Construyendo Agentes de IA que Trabajan Juntos",
         "url": "https://medium.com/@cammilo/getting-started-with-crewai-building-ai-agents-that-work-together-9c1f47f185ca",
         "type": "article"
       },
       {
-        "title": "Crew AI Full Tutorial For Beginners",
+        "title": "Tutorial Completo de Crew AI para Principiantes",
         "url": "https://www.youtube.com/watch?v=q6QLGS306d0",
         "type": "video"
       }
@@ -1639,125 +1639,125 @@
   },
   "eWxQiBrxIUG2JNcrdfIHS": {
     "title": "Smol Depot",
-    "description": "Smol Depot is an open-source kit that lets you bundle all the parts of a small AI agent in one place. You keep prompts, settings, and code files together in a single folder, then point the Depot tool at that folder to spin the agent up. The tool handles tasks such as loading models, saving chat history, and calling outside APIs, so you do not have to write that glue code yourself. A simple command can copy a starter template, letting you focus on the logic and prompts that make your agent special. Because everything lives in plain files, you can track changes with Git and share the agent like any other project.\n\nVisit the following resources to learn more:",
+    "description": "Smol Depot es un kit de código abierto que te permite agrupar todas las partes de un pequeño agente de IA en un solo lugar. Mantienes los prompts, la configuración y los archivos de código juntos en una sola carpeta, luego apuntas la herramienta Depot a esa carpeta para iniciar el agente. La herramienta maneja tareas como cargar modelos, guardar el historial de chat y llamar a API externas, para que no tengas que escribir ese código de unión tú mismo. Un simple comando puede copiar una plantilla de inicio, permitiéndote concentrarte en la lógica y los prompts que hacen especial a tu agente. Como todo reside en archivos de texto sin formato, puedes rastrear los cambios con Git y compartir el agente como cualquier otro proyecto.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "smol.ai - Continuous Fine-tuning Platform for AI Engineers",
+        "title": "smol.ai - Plataforma de Ajuste Fino Continuo para Ingenieros de IA",
         "url": "https://smol.candycode.dev/",
         "type": "article"
       },
       {
-        "title": "5-min Smol AI Tutorial",
+        "title": "Tutorial de Smol AI de 5 Minutos",
         "url": "https://www.ai-jason.com/learning-ai/smol-ai-tutorial",
         "type": "article"
       },
       {
-        "title": "Smol AI Full Beginner Course",
+        "title": "Curso Completo de Smol AI para Principiantes",
         "url": "https://www.youtube.com/watch?v=d7qFVrpLh34",
         "type": "video"
       }
     ]
   },
   "1EZFbDHA5J5_5BPMLMxXb": {
-    "title": "Anthropic Tool Use",
-    "description": "Anthropic Tool Use lets you connect a Claude model to real software functions so the agent can do useful tasks on its own. You give Claude a list of tools, each with a name, a short description, and a strict JSON schema that shows the allowed input fields. During a chat you send user text plus this tool list. Claude decides if a tool should run, picks one, and returns a JSON block that matches the schema. Your code reads the JSON, calls the matching function, and sends the result back to Claude for the next step. This loop repeats until no more tool calls are needed. Clear schemas, small field sets, and helpful examples make the calls accurate. By keeping the model in charge of choosing tools while your code controls real actions, you gain both flexibility and safety.\n\nVisit the following resources to learn more:",
+    "title": "Uso de Herramientas de Anthropic",
+    "description": "El Uso de Herramientas de Anthropic te permite conectar un modelo Claude a funciones de software reales para que el agente pueda realizar tareas útiles por sí solo. Le das a Claude una lista de herramientas, cada una con un nombre, una breve descripción y un esquema JSON estricto que muestra los campos de entrada permitidos. Durante un chat, envías texto de usuario más esta lista de herramientas. Claude decide si se debe ejecutar una herramienta, elige una y devuelve un bloque JSON que coincide con el esquema. Tu código lee el JSON, llama a la función correspondiente y envía el resultado de vuelta a Claude para el siguiente paso. Este bucle se repite hasta que no se necesiten más llamadas a herramientas. Esquemas claros, conjuntos de campos pequeños y ejemplos útiles hacen que las llamadas sean precisas. Al mantener el modelo a cargo de elegir las herramientas mientras tu código controla las acciones reales, obtienes flexibilidad y seguridad.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "Anthropic Tool Use",
+        "title": "Uso de Herramientas de Anthropic",
         "url": "https://docs.anthropic.com/en/docs/build-with-claude/tool-use/overview",
         "type": "article"
       }
     ]
   },
   "v8qLnyFRnEumodBYxQSXQ": {
-    "title": "Metrics to Track",
-    "description": "To judge how well an AI agent works, you need clear numbers. Track accuracy, precision, recall, and F1 score to measure correctness. For ranking tasks, use metrics like mean average precision or ROC-AUC. If users interact with the agent, monitor response time, latency, and failure rates. Safety metrics count toxic or biased outputs, while robustness tests check how the agent handles messy or tricky inputs. Resource metrics—memory, CPU, and energy—show if it can scale. Pick the metrics that match your goal, compare against a baseline, and track trends across versions.\n\nVisit the following resources to learn more:",
+    "title": "Métricas a Seguir",
+    "description": "Para juzgar qué tan bien funciona un agente de IA, necesitas números claros. Realiza un seguimiento de la exactitud, precisión, exhaustividad y puntuación F1 para medir la corrección. Para tareas de clasificación, utiliza métricas como la precisión media promedio o ROC-AUC. Si los usuarios interactúan con el agente, monitorea el tiempo de respuesta, la latencia y las tasas de falla. Las métricas de seguridad cuentan los resultados tóxicos o sesgados, mientras que las pruebas de robustez verifican cómo maneja el agente las entradas desordenadas o complicadas. Las métricas de recursos (memoria, CPU y energía) muestran si puede escalar. Elige las métricas que coincidan con tu objetivo, compáralas con una línea de base y realiza un seguimiento de las tendencias entre versiones.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "Robustness Testing for AI",
+        "title": "Pruebas de Robustez para IA",
         "url": "https://mitibmwatsonailab.mit.edu/category/robustness/",
         "type": "article"
       },
       {
-        "title": "Complete Guide to Machine Learning Evaluation Metrics",
+        "title": "Guía Completa de Métricas de Evaluación de Aprendizaje Automático",
         "url": "https://medium.com/analytics-vidhya/complete-guide-to-machine-learning-evaluation-metrics-615c2864d916",
         "type": "article"
       },
       {
-        "title": "Measuring Model Performance",
+        "title": "Midiendo el Rendimiento del Modelo",
         "url": "https://developers.google.com/machine-learning/crash-course/classification/accuracy",
         "type": "article"
       },
       {
-        "title": "A Practical Framework for (Gen)AI Value Measurement",
+        "title": "Un Marco Práctico para la Medición del Valor de la IA (Gen)AI",
         "url": "https://medium.com/google-cloud/a-practical-framework-for-gen-ai-value-measurement-5fccf3b66c43",
         "type": "article"
       }
     ]
   },
   "qo_O4YAe4-MTP_ZJoXJHR": {
-    "title": "Unit Testing for Individual Tools",
-    "description": "Unit testing checks that each tool an AI agent uses works as expected when it stands alone. You write small tests that feed the tool clear input and then compare its output to a known correct answer. If the tool is a function that parses dates, you test many date strings and see if the function gives the right results. Good tests cover normal cases, edge cases, and error cases. Run the tests every time you change the code. When a test fails, fix the tool before moving on. This habit keeps bugs from spreading into larger agent workflows and makes later debugging faster.\n\nVisit the following resources to learn more:",
+    "title": "Pruebas Unitarias para Herramientas Individuales",
+    "description": "Las pruebas unitarias verifican que cada herramienta que utiliza un agente de IA funcione como se espera cuando está sola. Escribes pruebas pequeñas que alimentan la herramienta con una entrada clara y luego comparas su salida con una respuesta correcta conocida. Si la herramienta es una función que analiza fechas, pruebas muchas cadenas de fechas y ves si la función da los resultados correctos. Las buenas pruebas cubren casos normales, casos límite y casos de error. Ejecuta las pruebas cada vez que cambies el código. Cuando una prueba falla, corrige la herramienta antes de continuar. Este hábito evita que los errores se propaguen a flujos de trabajo de agentes más grandes y acelera la depuración posterior.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "Unit Testing Agents",
+        "title": "Pruebas Unitarias de Agentes",
         "url": "https://docs.patronus.ai/docs/agent_evals/unit_testing",
         "type": "article"
       },
       {
-        "title": "Best AI Tools for Unit Testing: A Look at Top 14 AI Tools",
+        "title": "Las Mejores Herramientas de IA para Pruebas Unitarias: Un Vistazo a las 14 Mejores Herramientas de IA",
         "url": "https://thetrendchaser.com/best-ai-tools-for-unit-testing/",
         "type": "article"
       },
       {
-        "title": "AI for Unit Testing: Revolutionizing Developer Productivity",
+        "title": "IA para Pruebas Unitarias: Revolucionando la Productividad del Desarrollador",
         "url": "https://www.diffblue.com/resources/ai-for-unit-testing-revolutionizing-developer-productivity/",
         "type": "article"
       }
     ]
   },
   "P9-SiIda3TSjHsfkI5OUV": {
-    "title": "Integration Testing for Flows",
-    "description": "Integration testing for flows checks that an AI agent works well from the first user input to the final action, across every step in between. It joins all parts of the system—natural-language understanding, planning, memory, tools, and output—and runs them together in real scenarios. Test cases follow common and edge-case paths a user might take. The goal is to catch errors that only appear when parts interact, such as wrong data passed between modules or timing issues. Good practice includes building automated test suites, using real or mock services, and logging each step for easy debugging. When integration tests pass, you gain confidence that the whole flow feels smooth and reliable for users.\n\nVisit the following resources to learn more:",
+    "title": "Pruebas de Integración para Flujos",
+    "description": "Las pruebas de integración para flujos verifican que un agente de IA funcione bien desde la primera entrada del usuario hasta la acción final, a través de cada paso intermedio. Une todas las partes del sistema —comprensión del lenguaje natural, planificación, memoria, herramientas y salida— y las ejecuta juntas en escenarios reales. Los casos de prueba siguen rutas comunes y de casos límite que un usuario podría tomar. El objetivo es detectar errores que solo aparecen cuando las partes interactúan, como datos incorrectos pasados entre módulos o problemas de temporización. Las buenas prácticas incluyen la creación de conjuntos de pruebas automatizadas, el uso de servicios reales o simulados y el registro de cada paso para facilitar la depuración. Cuando las pruebas de integración pasan, ganas confianza en que todo el flujo se siente fluido y confiable para los usuarios.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "Integration Testing for AI-based Features with Humans",
+        "title": "Pruebas de Integración para Funciones Basadas en IA con Humanos",
         "url": "https://www.microsoft.com/en-us/research/publication/hint-integration-testing-for-ai-based-features-with-humans-in-the-loop/",
         "type": "article"
       },
       {
-        "title": "Integration Testing and Unit Testing in AI",
+        "title": "Pruebas de Integración y Pruebas Unitarias en IA",
         "url": "https://www.aviator.co/blog/integration-testing-and-unit-testing-in-the-age-of-ai/",
         "type": "article"
       },
       {
-        "title": "Integration Testing",
+        "title": "Pruebas de Integración",
         "url": "https://www.guru99.com/integration-testing.html",
         "type": "article"
       }
     ]
   },
   "rHxdxN97ZcU7MPl8L1jzN": {
-    "title": "Human in the Loop Evaluation",
-    "description": "Human-in-the-loop evaluation checks an AI agent by letting real people judge its output and behavior. Instead of trusting only automated scores, testers invite users, domain experts, or crowd workers to watch tasks, label answers, flag errors, and rate clarity, fairness, or safety. Their feedback shows problems that numbers alone miss, such as hidden bias, confusing language, or actions that feel wrong to a person. Teams study these notes, adjust the model, and run another round, repeating until the agent meets quality and trust goals. Mixing human judgment with data leads to a system that is more accurate, useful, and safe for everyday use.\n\nVisit the following resources to learn more:",
+    "title": "Evaluación Humana en el Bucle",
+    "description": "La evaluación humana en el bucle verifica un agente de IA permitiendo que personas reales juzguen su salida y comportamiento. En lugar de confiar solo en puntuaciones automatizadas, los probadores invitan a usuarios, expertos en el dominio o trabajadores de crowdsourcing a observar tareas, etiquetar respuestas, marcar errores y calificar la claridad, equidad o seguridad. Sus comentarios muestran problemas que los números por sí solos omiten, como sesgos ocultos, lenguaje confuso o acciones que una persona considera incorrectas. Los equipos estudian estas notas, ajustan el modelo y ejecutan otra ronda, repitiendo hasta que el agente cumpla con los objetivos de calidad y confianza. Mezclar el juicio humano con los datos conduce a un sistema más preciso, útil y seguro para el uso diario.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "Human in the Loop · Cloudflare Agents",
+        "title": "Humano en el Bucle · Agentes de Cloudflare",
         "url": "https://developers.cloudflare.com/agents/concepts/human-in-the-loop/",
         "type": "article"
       },
       {
-        "title": "What is Human-in-the-Loop: A Guide",
+        "title": "¿Qué es Humano en el Bucle?: Una Guía",
         "url": "https://logifusion.com/what-is-human-in-the-loop-htil/",
         "type": "article"
       },
       {
-        "title": "Human-in-the-Loop ML",
+        "title": "ML con Humano en el Bucle",
         "url": "https://docs.aws.amazon.com/sagemaker/latest/dg/sms-human-review-workflow.html",
         "type": "article"
       },
       {
-        "title": "The Importance of Human Feedback in AI (Hugging Face Blog)",
+        "title": "La Importancia de la Retroalimentación Humana en la IA (Blog de Hugging Face)",
         "url": "https://huggingface.co/blog/rlhf",
         "type": "article"
       }
@@ -1765,7 +1765,7 @@
   },
   "xp7TCTRE9HP60_rGzTUF6": {
     "title": "LangSmith",
-    "description": "LangSmith is a tool that helps you see how well your AI agents work. It lets you record every step the agent takes, from the first input to the final answer. You can replay these steps to find places where the agent goes wrong. LangSmith also lets you create test sets with real user prompts and compare new model versions against them. It shows clear numbers on speed, cost, and accuracy so you can spot trade-offs. Because LangSmith links to LangChain, you can add it with only a few extra lines of code. The web dashboard then gives charts, error logs, and side-by-side result views. This makes it easy to track progress, fix bugs, and prove that your agent is getting better over time.\n\nVisit the following resources to learn more:",
+    "description": "LangSmith es una herramienta que te ayuda a ver qué tan bien funcionan tus agentes de IA. Te permite registrar cada paso que da el agente, desde la primera entrada hasta la respuesta final. Puedes reproducir estos pasos para encontrar lugares donde el agente se equivoca. LangSmith también te permite crear conjuntos de pruebas con prompts de usuarios reales y comparar nuevas versiones del modelo con ellos. Muestra números claros sobre velocidad, costo y precisión para que puedas detectar compensaciones. Como LangSmith se vincula a LangChain, puedes agregarlo con solo unas pocas líneas de código adicionales. El panel web luego ofrece gráficos, registros de errores y vistas de resultados lado a lado. Esto facilita el seguimiento del progreso, la corrección de errores y la demostración de que tu agente está mejorando con el tiempo.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
         "title": "LangSmith",
@@ -1773,17 +1773,17 @@
         "type": "article"
       },
       {
-        "title": "LangSmith Documentation",
+        "title": "Documentación de LangSmith",
         "url": "https://docs.smith.langchain.com/",
         "type": "article"
       },
       {
-        "title": "Harden your application with LangSmith Evaluation",
+        "title": "Fortalece tu aplicación con la Evaluación de LangSmith",
         "url": "https://www.langchain.com/evaluation",
         "type": "article"
       },
       {
-        "title": "What is LangSmith and Why should I care as a developer?",
+        "title": "¿Qué es LangSmith y Por Qué Debería Importarme como Desarrollador?",
         "url": "https://medium.com/around-the-prompt/what-is-langsmith-and-why-should-i-care-as-a-developer-e5921deb54b5",
         "type": "article"
       }
@@ -1791,7 +1791,7 @@
   },
   "YzEDtGEaMaMWVt0W03HRt": {
     "title": "Ragas",
-    "description": "Ragas is an open-source tool used to check how well a Retrieval-Augmented Generation (RAG) agent works. You give it the user question, the passages the agent pulled from a knowledge base, and the final answer. Ragas then scores the answer for things like correctness, relevance, and whether the cited passages really support the words in the answer. It uses large language models under the hood, so you do not need to write your own scoring rules. Results appear in a clear report that shows strong and weak spots in the pipeline. With this feedback you can change prompts, retriever settings, or model choices and quickly see if quality goes up. This makes testing RAG systems faster, repeatable, and less guess-based.\n\nVisit the following resources to learn more:",
+    "description": "Ragas es una herramienta de código abierto utilizada para verificar qué tan bien funciona un agente de Generación Aumentada por Recuperación (RAG). Le das la pregunta del usuario, los pasajes que el agente extrajo de una base de conocimientos y la respuesta final. Ragas luego califica la respuesta por cosas como corrección, relevancia y si los pasajes citados realmente respaldan las palabras de la respuesta. Utiliza modelos de lenguaje grandes internamente, por lo que no necesitas escribir tus propias reglas de puntuación. Los resultados aparecen en un informe claro que muestra los puntos fuertes y débiles de la canalización. Con esta retroalimentación puedes cambiar los prompts, la configuración del recuperador o las opciones del modelo y ver rápidamente si la calidad mejora. Esto hace que probar los sistemas RAG sea más rápido, repetible y menos basado en conjeturas.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
         "title": "explodinggradients/ragas",
@@ -1799,12 +1799,12 @@
         "type": "opensource"
       },
       {
-        "title": "Ragas Documentation",
+        "title": "Documentación de Ragas",
         "url": "https://docs.ragas.io/en/latest/",
         "type": "article"
       },
       {
-        "title": "Evaluating RAG Applications with RAGAs",
+        "title": "Evaluación de Aplicaciones RAG con RAGAs",
         "url": "https://towardsdatascience.com/evaluating-rag-applications-with-ragas-81d67b0ee31a/n",
         "type": "article"
       }
@@ -1812,46 +1812,46 @@
   },
   "0924QUH1wV7Mp-Xu0FAhF": {
     "title": "DeepEval",
-    "description": "DeepEval is an open-source tool that helps you test and score the answers your AI agent gives. You write small test cases that show an input and the reply you hope to get, or a rule the reply must follow. DeepEval runs the agent, checks the reply with built-in measures such as similarity, accuracy, or safety, and then marks each test as pass or fail. You can add your own checks, store tests in code or YAML files, and run them in a CI pipeline so every new model or prompt version gets the same quick audit. The fast feedback makes it easy to spot errors, cut down on hallucinations, and compare different models before you ship.\n\nVisit the following resources to learn more:",
+    "description": "DeepEval es una herramienta de código abierto que te ayuda a probar y calificar las respuestas que da tu agente de IA. Escribes pequeños casos de prueba que muestran una entrada y la respuesta que esperas obtener, o una regla que la respuesta debe seguir. DeepEval ejecuta el agente, comprueba la respuesta con medidas integradas como similitud, precisión o seguridad, y luego marca cada prueba como aprobada o fallida. Puedes agregar tus propias comprobaciones, almacenar pruebas en archivos de código o YAML, y ejecutarlas en una canalización de CI para que cada nueva versión del modelo o prompt reciba la misma auditoría rápida. La retroalimentación rápida facilita la detección de errores, la reducción de alucinaciones y la comparación de diferentes modelos antes de enviarlos.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "DeepEval GitHub Repository",
+        "title": "Repositorio de GitHub de DeepEval",
         "url": "https://github.com/confident-ai/deepeval",
         "type": "opensource"
       },
       {
-        "title": "DeepEval - The Open-Source LLM Evaluation Framework",
+        "title": "DeepEval - El Marco de Evaluación LLM de Código Abierto",
         "url": "https://www.deepeval.com/",
         "type": "article"
       },
       {
-        "title": "Evaluate LLMs Effectively Using DeepEval: A Pratical Guide",
+        "title": "Evalúa LLMs Eficazmente Usando DeepEval: Una Guía Práctica",
         "url": "https://www.datacamp.com/tutorial/deepeval",
         "type": "article"
       },
       {
-        "title": "DeepEval - LLM Evaluation Framework",
+        "title": "DeepEval - Marco de Evaluación LLM",
         "url": "https://www.youtube.com/watch?v=ZNs2dCXHlfo",
         "type": "video"
       }
     ]
   },
   "zs6LM8WEnb0ERWpiaQCgc": {
-    "title": "Structured logging & tracing",
-    "description": "Structured logging and tracing are ways to record what an AI agent does so you can find and fix problems fast. Instead of dumping plain text, the agent writes logs in a fixed key-value format, such as time, user\\_id, step, and message. Because every entry follows the same shape, search tools can filter, sort, and count events with ease. Tracing links those log lines into a chain that follows one request or task across many functions, threads, or microservices. By adding a unique trace ID to each step, you can see how long each part took and where errors happened. Together, structured logs and traces offer clear, machine-readable data that helps developers spot slow code paths, unusual behavior, and hidden bugs without endless manual scans.\n\nVisit the following resources to learn more:",
+    "title": "Registro estructurado y rastreo",
+    "description": "El registro estructurado y el rastreo son formas de registrar lo que hace un agente de IA para que puedas encontrar y solucionar problemas rápidamente. En lugar de volcar texto sin formato, el agente escribe registros en un formato fijo de clave-valor, como tiempo, id_usuario, paso y mensaje. Como cada entrada sigue la misma forma, las herramientas de búsqueda pueden filtrar, ordenar y contar eventos con facilidad. El rastreo vincula esas líneas de registro en una cadena que sigue una solicitud o tarea a través de muchas funciones, hilos o microservicios. Al agregar un ID de rastreo único a cada paso, puedes ver cuánto tiempo tomó cada parte y dónde ocurrieron los errores. Juntos, los registros estructurados y los rastreos ofrecen datos claros y legibles por máquina que ayudan a los desarrolladores a detectar rutas de código lentas, comportamientos inusuales y errores ocultos sin interminables escaneos manuales.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "Understanding Structured Logging: A Comprehensive Guide",
+        "title": "Comprendiendo el Registro Estructurado: Una Guía Completa",
         "url": "https://www.graphapp.ai/blog/understanding-structured-logging-a-comprehensive-guide",
         "type": "article"
       },
       {
-        "title": "Structured Logging & Cloud Logging",
+        "title": "Registro Estructurado y Registro en la Nube",
         "url": "https://cloud.google.com/logging/docs/structured-logging",
         "type": "article"
       },
       {
-        "title": "Best Practices for Logging in AI Applications",
+        "title": "Mejores Prácticas para el Registro en Aplicaciones de IA",
         "url": "https://www.restack.io/p/best-ai-practices-software-compliance-answer-logging-best-practices-cat-ai",
         "type": "article"
       }
@@ -1859,7 +1859,7 @@
   },
   "SS8mGqf9wfrNqenIWvN8Z": {
     "title": "LangSmith",
-    "description": "LangSmith is a web tool that helps you see and fix what your AI agents are doing. It records each call that the agent makes to a language model, the input it used, and the answer it got back. You can replay any step, compare different prompts, measure cost, speed, and error rates, and tag runs for easy search. It also lets you store test sets and run quick checks so you know if new code makes the agent worse. By showing clear traces and charts, LangSmith makes it easier to debug, improve, and trust AI systems built with LangChain or other frameworks.\n\nVisit the following resources to learn more:",
+    "description": "LangSmith es una herramienta web que te ayuda a ver y corregir lo que hacen tus agentes de IA. Registra cada llamada que el agente hace a un modelo de lenguaje, la entrada que usó y la respuesta que obtuvo. Puedes reproducir cualquier paso, comparar diferentes prompts, medir costos, velocidad y tasas de error, y etiquetar ejecuciones para facilitar la búsqueda. También te permite almacenar conjuntos de pruebas y ejecutar comprobaciones rápidas para saber si el nuevo código empeora el agente. Al mostrar rastreos y gráficos claros, LangSmith facilita la depuración, mejora y confianza en los sistemas de IA creados con LangChain u otros marcos.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
         "title": "LangSmith",
@@ -1867,17 +1867,17 @@
         "type": "article"
       },
       {
-        "title": "LangSmith Documentation",
+        "title": "Documentación de LangSmith",
         "url": "https://docs.smith.langchain.com/",
         "type": "article"
       },
       {
-        "title": "Harden your application with LangSmith Evaluation",
+        "title": "Fortalece tu aplicación con la Evaluación de LangSmith",
         "url": "https://www.langchain.com/evaluation",
         "type": "article"
       },
       {
-        "title": "What is LangSmith and Why should I care as a developer?",
+        "title": "¿Qué es LangSmith y Por Qué Debería Importarme como Desarrollador?",
         "url": "https://medium.com/around-the-prompt/what-is-langsmith-and-why-should-i-care-as-a-developer-e5921deb54b5",
         "type": "article"
       }
@@ -1885,7 +1885,7 @@
   },
   "MLxP5N0Vrmwh-kyvNeGXn": {
     "title": "Helicone",
-    "description": "Helicone is an open-source tool that helps you watch and understand how your AI agents talk to large language models. You send your model calls through Helicone’s proxy, and it records each request and response without changing the result. A clear web dashboard then shows logs, latency, token counts, error rates, and cost for every call. You can filter, search, and trace a single user journey, which makes it easy to spot slow prompts or rising costs. Helicone also lets you set alerts and share traces with your team, so problems get fixed fast and future changes are safer.\n\nVisit the following resources to learn more:",
+    "description": "Helicone es una herramienta de código abierto que te ayuda a observar y comprender cómo tus agentes de IA hablan con modelos de lenguaje grandes. Envías las llamadas de tu modelo a través del proxy de Helicone, y este registra cada solicitud y respuesta sin cambiar el resultado. Un panel web claro muestra luego registros, latencia, recuento de tokens, tasas de error y costo de cada llamada. Puedes filtrar, buscar y rastrear el recorrido de un solo usuario, lo que facilita la detección de prompts lentos o costos crecientes. Helicone también te permite configurar alertas y compartir rastreos con tu equipo, para que los problemas se solucionen rápidamente y los cambios futuros sean más seguros.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
         "title": "Helicone/helicone",
@@ -1898,7 +1898,7 @@
         "type": "article"
       },
       {
-        "title": "Helicone OSS LLM Observability",
+        "title": "Observabilidad LLM de Código Abierto de Helicone",
         "url": "https://docs.helicone.ai/getting-started/quick-start",
         "type": "article"
       }
@@ -1906,7 +1906,7 @@
   },
   "UoIheaJlShiceafrWALEH": {
     "title": "LangFuse",
-    "description": "LangFuse is a free, open-source tool that lets you watch and debug AI agents while they run. You add a small code snippet to your agent, and LangFuse starts collecting every prompt, model response, and user input. It shows this data as neat timelines, so you can see each step the agent takes, how long the calls cost, and where errors happen. You can tag runs, search through them, and compare different prompt versions to find what works best. The dashboard also tracks token usage and latency, helping you cut cost and improve speed. Because LangFuse stores data in your own database, you keep full control of sensitive text. It works well with popular frameworks like LangChain and can send alerts to Slack or email when something breaks.\n\nVisit the following resources to learn more:",
+    "description": "LangFuse es una herramienta gratuita y de código abierto que te permite observar y depurar agentes de IA mientras se ejecutan. Agregas un pequeño fragmento de código a tu agente y LangFuse comienza a recopilar cada prompt, respuesta del modelo y entrada del usuario. Muestra estos datos como líneas de tiempo ordenadas, para que puedas ver cada paso que da el agente, cuánto cuestan las llamadas y dónde ocurren los errores. Puedes etiquetar ejecuciones, buscarlas y comparar diferentes versiones de prompts para encontrar la que funciona mejor. El panel también realiza un seguimiento del uso de tokens y la latencia, lo que te ayuda a reducir costos y mejorar la velocidad. Como LangFuse almacena datos en tu propia base de datos, mantienes el control total del texto confidencial. Funciona bien con marcos populares como LangChain y puede enviar alertas a Slack o correo electrónico cuando algo se rompe.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
         "title": "langfuse/langfuse",
@@ -1919,12 +1919,12 @@
         "type": "article"
       },
       {
-        "title": "LangFuse Documentation",
+        "title": "Documentación de LangFuse",
         "url": "https://langfuse.com/docs",
         "type": "article"
       },
       {
-        "title": "Langfuse: Open Source LLM Engineering Platform",
+        "title": "Langfuse: Plataforma de Ingeniería LLM de Código Abierto",
         "url": "https://www.ycombinator.com/companies/langfuse",
         "type": "article"
       }
@@ -1932,7 +1932,7 @@
   },
   "7UqPXUzqKYXklnB3x-tsv": {
     "title": "openllmetry",
-    "description": "openllmetry is a small Python library that makes it easy to watch what your AI agent is doing and how well it is working. It wraps calls to large-language-model APIs, vector stores, and other tools, then sends logs, traces, and simple metrics to any backend that speaks the OpenTelemetry standard, such as Jaeger, Zipkin, or Grafana. You add one or two lines of code at start-up, and the library captures prompt text, model name, latency, token counts, and costs each time the agent asks the model for an answer. The data helps you spot slow steps, high spend, or bad answers, and it lets you play back full traces to debug agent chains. Because it follows OpenTelemetry, you can mix these AI traces with normal service traces and see the whole flow in one place.\n\nVisit the following resources to learn more:",
+    "description": "openllmetry es una pequeña biblioteca de Python que facilita observar lo que hace tu agente de IA y qué tan bien está funcionando. Envuelve las llamadas a las API de modelos de lenguaje grandes, almacenes de vectores y otras herramientas, luego envía registros, rastreos y métricas simples a cualquier backend que hable el estándar OpenTelemetry, como Jaeger, Zipkin o Grafana. Agregas una o dos líneas de código al inicio, y la biblioteca captura el texto del prompt, el nombre del modelo, la latencia, el recuento de tokens y los costos cada vez que el agente le pide una respuesta al modelo. Los datos te ayudan a detectar pasos lentos, gastos elevados o respuestas incorrectas, y te permite reproducir rastreos completos para depurar cadenas de agentes. Como sigue OpenTelemetry, puedes mezclar estos rastreos de IA con rastreos de servicios normales y ver todo el flujo en un solo lugar.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
         "title": "traceloop/openllmetry",
@@ -1940,122 +1940,122 @@
         "type": "opensource"
       },
       {
-        "title": "OpenTelemetry Documentation",
+        "title": "Documentación de OpenTelemetry",
         "url": "https://www.traceloop.com/blog/openllmetry",
         "type": "article"
       },
       {
-        "title": "What is OpenLLMetry? - traceloop",
+        "title": "¿Qué es OpenLLMetry? - traceloop",
         "url": "https://www.traceloop.com/docs/openllmetry/introduction",
         "type": "article"
       },
       {
-        "title": "Use Traceloop with Python",
+        "title": "Usa Traceloop con Python",
         "url": "https://www.traceloop.com/docs/openllmetry/getting-started-python",
         "type": "article"
       }
     ]
   },
   "SU2RuicMUo8tiAsQtDI1k": {
-    "title": "Prompt Injection / Jailbreaks",
-    "description": "Prompt injection, also called a jailbreak, is a trick that makes an AI system break its own rules. An attacker hides special words or symbols inside normal-looking text. When the AI reads this text, it follows the hidden instructions instead of its safety rules. The attacker might force the AI to reveal private data, produce harmful content, or give wrong advice. This risk grows when the AI talks to other software or pulls text from the internet, because harmful prompts can slip in without warning. Good defenses include cleaning user input, setting strong guardrails inside the model, checking outputs for policy breaks, and keeping humans in the loop for high-risk tasks.\n\nVisit the following resources to learn more:",
+    "title": "Inyección de Prompts / Jailbreaks",
+    "description": "La inyección de prompts, también llamada jailbreak, es un truco que hace que un sistema de IA rompa sus propias reglas. Un atacante esconde palabras o símbolos especiales dentro de texto de apariencia normal. Cuando la IA lee este texto, sigue las instrucciones ocultas en lugar de sus reglas de seguridad. El atacante podría forzar a la IA a revelar datos privados, producir contenido dañino o dar consejos incorrectos. Este riesgo crece cuando la IA habla con otro software o extrae texto de Internet, porque los prompts dañinos pueden colarse sin previo aviso. Buenas defensas incluyen limpiar la entrada del usuario, establecer barreras de protección sólidas dentro del modelo, verificar las salidas en busca de violaciones de políticas y mantener a los humanos en el bucle para tareas de alto riesgo.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "Prompt Injection vs. Jailbreaking: What's the Difference?",
+        "title": "Inyección de Prompts vs. Jailbreaking: ¿Cuál es la Diferencia?",
         "url": "https://learnprompting.org/blog/injection_jailbreaking",
         "type": "article"
       },
       {
-        "title": "Prompt Injection vs Prompt Jailbreak",
+        "title": "Inyección de Prompts vs Jailbreak de Prompts",
         "url": "https://codoid.com/ai/prompt-injection-vs-prompt-jailbreak-a-detailed-comparison/",
         "type": "article"
       },
       {
-        "title": "How Prompt Attacks Exploit GenAI and How to Fight Back",
+        "title": "Cómo los Ataques de Prompts Explotan la GenAI y Cómo Defenderse",
         "url": "https://unit42.paloaltonetworks.com/new-frontier-of-genai-threats-a-comprehensive-guide-to-prompt-attacks/",
         "type": "article"
       }
     ]
   },
   "UVzLGXG6K7HQVHmw8ZAv2": {
-    "title": "Tool sandboxing / Permissioning",
-    "description": "Tool sandboxing keeps the AI agent inside a safe zone where it can only run approved actions and cannot touch the wider system. Permissioning sets clear rules that say which files, networks, or commands the agent may use. Together they stop errors, leaks, or abuse by limiting what the agent can reach and do. Developers grant the smallest set of rights, watch activity, and block anything outside the plan. If the agent needs new access, it must ask and get a fresh permit. This simple fence protects user data, reduces harm, and builds trust in the agent’s work.\n\nVisit the following resources to learn more:",
+    "title": "Sandboxing de Herramientas / Permisos",
+    "description": "El sandboxing de herramientas mantiene al agente de IA dentro de una zona segura donde solo puede ejecutar acciones aprobadas y no puede tocar el sistema más amplio. Los permisos establecen reglas claras que dicen qué archivos, redes o comandos puede usar el agente. Juntos detienen errores, filtraciones o abusos al limitar lo que el agente puede alcanzar y hacer. Los desarrolladores otorgan el conjunto más pequeño de derechos, observan la actividad y bloquean cualquier cosa fuera del plan. Si el agente necesita un nuevo acceso, debe preguntar y obtener un permiso nuevo. Esta simple cerca protege los datos del usuario, reduce el daño y genera confianza en el trabajo del agente.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "AI Sandbox | Harvard University Information Technology",
+        "title": "Sandbox de IA | Tecnología de la Información de la Universidad de Harvard",
         "url": "https://www.huit.harvard.edu/ai-sandbox",
         "type": "article"
       },
       {
-        "title": "How to Set Up AI Sandboxes to Maximize Adoption",
+        "title": "Cómo Configurar Sandboxes de IA para Maximizar la Adopción",
         "url": "https://medium.com/@emilholmegaard/how-to-set-up-ai-sandboxes-to-maximize-adoption-without-compromising-ethics-and-values-637c70626130",
         "type": "article"
       },
       {
-        "title": "Sandboxes for AI - The Datasphere Initiative",
+        "title": "Sandboxes para IA - La Iniciativa Datasphere",
         "url": "https://www.thedatasphere.org/datasphere-publish/sandboxes-for-ai/",
         "type": "article"
       }
     ]
   },
   "rdlYBJNNyZUshzsJawME4": {
-    "title": "Data Privacy + PII Redaction",
-    "description": "AI agents often process text, images, and logs that include personal data like names, phone numbers, or addresses. Leaks can cause fraud, stalking, or other harm, so laws like GDPR and CCPA require strict protections. A key method is PII redaction: scanning inputs and outputs to find and mask any personal details before storage or sharing. Redaction uses pattern rules, machine learning, or both. Teams should also keep audit logs, enforce access controls, and test their redaction flows often to prevent leaks.\n\nVisit the following resources to learn more:",
+    "title": "Privacidad de Datos + Redacción de PII",
+    "description": "Los agentes de IA a menudo procesan texto, imágenes y registros que incluyen datos personales como nombres, números de teléfono o direcciones. Las filtraciones pueden causar fraude, acoso u otros daños, por lo que leyes como el RGPD y la CCPA requieren protecciones estrictas. Un método clave es la redacción de PII: escanear entradas y salidas para encontrar y enmascarar cualquier detalle personal antes de almacenarlo o compartirlo. La redacción utiliza reglas de patrones, aprendizaje automático o ambos. Los equipos también deben mantener registros de auditoría, hacer cumplir los controles de acceso y probar sus flujos de redacción con frecuencia para evitar filtraciones.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "GDPR Compliance Overview",
+        "title": "Descripción General del Cumplimiento del RGPD",
         "url": "https://gdpr.eu/",
         "type": "article"
       },
       {
-        "title": "Protect Sensitive Data with PII Redaction Software",
+        "title": "Protege Datos Confidenciales con Software de Redacción de PII",
         "url": "https://redactor.ai/blog/pii-redaction-software-guide",
         "type": "article"
       },
       {
-        "title": "A Complete Guide on PII Redaction",
+        "title": "Una Guía Completa sobre la Redacción de PII",
         "url": "https://enthu.ai/blog/what-is-pii-redaction/",
         "type": "article"
       }
     ]
   },
   "EyLo2j8IQsIK91SKaXkmK": {
-    "title": "Bias & Toxicity Guardrails",
-    "description": "Bias and toxicity guardrails keep an AI agent from giving unfair or harmful results. Bias shows up when training data favors certain groups or views. Toxicity is language that is hateful, violent, or rude. To stop this, start with clean and balanced data. Remove slurs, stereotypes, and spam. Add examples from many voices so the model learns fair patterns. During training, test the model often and adjust weights or rules that lean one way. After training, put filters in place that block toxic words or flag unfair answers before users see them. Keep logs, run audits, and ask users for feedback to catch new issues early. Write down every step so builders and users know the limits and risks. These actions protect people, follow laws, and help users trust the AI.\n\nVisit the following resources to learn more:",
+    "title": "Barreras de Protección contra Sesgos y Toxicidad",
+    "description": "Las barreras de protección contra sesgos y toxicidad evitan que un agente de IA dé resultados injustos o dañinos. El sesgo aparece cuando los datos de entrenamiento favorecen a ciertos grupos o puntos de vista. La toxicidad es un lenguaje odioso, violento o grosero. Para detener esto, comienza con datos limpios y equilibrados. Elimina insultos, estereotipos y spam. Agrega ejemplos de muchas voces para que el modelo aprenda patrones justos. Durante el entrenamiento, prueba el modelo con frecuencia y ajusta los pesos o reglas que se inclinen hacia un lado. Después del entrenamiento, implementa filtros que bloqueen palabras tóxicas o marquen respuestas injustas antes de que los usuarios las vean. Mantén registros, ejecuta auditorías y solicita comentarios a los usuarios para detectar nuevos problemas a tiempo. Anota cada paso para que los constructores y usuarios conozcan los límites y riesgos. Estas acciones protegen a las personas, cumplen con las leyes y ayudan a los usuarios a confiar en la IA.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "Define the Agent Guardrails",
+        "title": "Define las Barreras de Protección del Agente",
         "url": "https://trailhead.salesforce.com/content/learn/modules/agentforce-agent-planning/define-the-agent-guardrails",
         "type": "article"
       },
       {
-        "title": "How to Build Safe AI Agents: Best Practices for Guardrails",
+        "title": "Cómo Construir Agentes de IA Seguros: Mejores Prácticas para Barreras de Protección",
         "url": "https://medium.com/@sahin.samia/how-to-build-safe-ai-agents-best-practices-for-guardrails-and-oversight-a0085b50c022",
         "type": "article"
       }
     ]
   },
   "63nsfJFO1BwjLX_ZVaPFC": {
-    "title": "Safety + Red Team Testing",
-    "description": "Safety + Red Team Testing is the practice of checking an AI agent for harmful or risky behavior before and after release. Safety work sets rules, guardrails, and alarms so the agent follows laws, keeps data private, and treats people fairly. Red team testing sends skilled testers to act like attackers or troublemakers. They type tricky prompts, try to leak private data, force biased outputs, or cause the agent to give dangerous advice. Every weakness they find is logged and fixed by adding filters, better training data, stronger limits, or live monitoring. Running these tests often lowers the chance of real-world harm and builds trust with users and regulators.\n\nVisit the following resources to learn more:",
+    "title": "Seguridad + Pruebas de Equipo Rojo",
+    "description": "Las Pruebas de Seguridad + Equipo Rojo son la práctica de verificar un agente de IA en busca de comportamientos dañinos o riesgosos antes y después del lanzamiento. El trabajo de seguridad establece reglas, barreras de protección y alarmas para que el agente cumpla con las leyes, mantenga la privacidad de los datos y trate a las personas de manera justa. Las pruebas de equipo rojo envían probadores calificados para que actúen como atacantes o alborotadores. Escriben prompts engañosos, intentan filtrar datos privados, fuerzan resultados sesgados o hacen que el agente dé consejos peligrosos. Cada debilidad que encuentran se registra y se corrige agregando filtros, mejores datos de entrenamiento, límites más estrictos o monitoreo en vivo. Realizar estas pruebas con frecuencia reduce la posibilidad de daños en el mundo real y genera confianza con los usuarios y reguladores.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "Visit Dedicated AI Red Teaming Roadmap",
+        "title": "Visita el Roadmap Dedicado de Pruebas de Equipo Rojo de IA",
         "url": "https://roadmap.sh/ai-red-teaming",
         "type": "article"
       },
       {
-        "title": "Enhancing AI safety: Insights and lessons from red teaming",
+        "title": "Mejorando la seguridad de la IA: Perspectivas y lecciones de las pruebas de equipo rojo",
         "url": "https://www.microsoft.com/en-us/microsoft-cloud/blog/2025/01/14/enhancing-ai-safety-insights-and-lessons-from-red-teaming/",
         "type": "article"
       },
       {
-        "title": "AI Safety Testing in the Absence of Regulations",
+        "title": "Pruebas de Seguridad de IA en Ausencia de Regulaciones",
         "url": "https://aisecuritycentral.com/ai-safety-testing/",
         "type": "article"
       },
       {
-        "title": "A Guide to AI Red Teaming - HiddenLayer",
+        "title": "Una Guía para las Pruebas de Equipo Rojo de IA - HiddenLayer",
         "url": "https://hiddenlayer.com/innovation-hub/a-guide-to-ai-red-teaming/",
         "type": "article"
       }

--- a/public/roadmap-content/ai-data-scientist.json
+++ b/public/roadmap-content/ai-data-scientist.json
@@ -1,252 +1,252 @@
 {
   "aStaDENn5PhEa-cFvNzXa": {
-    "title": "Mathematics",
-    "description": "Mathematics is the foundation of AI and Data Science. It is essential to have a good understanding of mathematics to excel in these fields.",
+    "title": "Matemáticas",
+    "description": "Las matemáticas son la base de la IA y la Ciencia de Datos. Es fundamental tener una buena comprensión de las matemáticas para destacar en estos campos.",
     "links": [
       {
-        "title": "Mathematics for Machine Learning",
+        "title": "Matemáticas para el Aprendizaje Automático",
         "url": "https://imp.i384100.net/baqMYv",
         "type": "article"
       },
       {
-        "title": "Algebra and Differential Calculus",
+        "title": "Álgebra y Cálculo Diferencial",
         "url": "https://imp.i384100.net/LX5M7M",
         "type": "article"
       }
     ]
   },
   "4WZL_fzJ3cZdWLLDoWN8D": {
-    "title": "Statistics",
-    "description": "Statistics is the science of collecting, analyzing, interpreting, presenting, and organizing data. It is a branch of mathematics that deals with the collection, analysis, interpretation, presentation, and organization of data. It is used in a wide range of fields, including science, engineering, medicine, and social science. Statistics is used to make informed decisions, to predict future events, and to test hypotheses. It is also used to summarize data, to describe relationships between variables, and to make inferences about populations based on samples.\n\nLearn more from the resources given on the roadmap.",
+    "title": "Estadísticas",
+    "description": "La estadística es la ciencia de recolectar, analizar, interpretar, presentar y organizar datos. Es una rama de las matemáticas que se ocupa de la recolección, análisis, interpretación, presentación y organización de datos. Se utiliza en una amplia gama de campos, incluyendo ciencia, ingeniería, medicina y ciencias sociales. La estadística se utiliza para tomar decisiones informadas, predecir eventos futuros y probar hipótesis. También se utiliza para resumir datos, describir relaciones entre variables y hacer inferencias sobre poblaciones basadas en muestras.\n\nAprende más de los recursos dados en el roadmap.",
     "links": []
   },
   "gWMvD83hVXeTmCuHGIiOL": {
-    "title": "Linear Algebra, Calculus, Mathematical Analysis",
+    "title": "Álgebra Lineal, Cálculo, Análisis Matemático",
     "description": "",
     "links": [
       {
-        "title": "Mathematics for Machine Learning Specialization",
+        "title": "Especialización en Matemáticas para el Aprendizaje Automático",
         "url": "https://imp.i384100.net/baqMYv",
         "type": "article"
       },
       {
-        "title": "Explore top posts about Math",
+        "title": "Explora las mejores publicaciones sobre Matemáticas",
         "url": "https://app.daily.dev/tags/math?ref=roadmapsh",
         "type": "article"
       },
       {
-        "title": "Linear Algebra Youtube Course",
+        "title": "Curso de Álgebra Lineal en Youtube",
         "url": "https://www.youtube.com/playlist?list=PLZHQObOWTQDPD3MizzM2xVFitgF8hE_ab",
         "type": "video"
       }
     ]
   },
   "mwPJh33MEUQ4Co_LiVEOb": {
-    "title": "Differential Calculus ",
+    "title": "Cálculo Diferencial",
     "description": "",
     "links": [
       {
-        "title": "Algebra and Differential Calculus for Data Science",
+        "title": "Álgebra y Cálculo Diferencial para Ciencia de Datos",
         "url": "https://imp.i384100.net/LX5M7M",
         "type": "article"
       },
       {
-        "title": "Calculus Youtube Course",
+        "title": "Curso de Cálculo en YouTube",
         "url": "https://www.youtube.com/playlist?list=PLZHQObOWTQDMsr9K-rj53DwVRMYO3t5Yr",
         "type": "video"
       }
     ]
   },
   "Y9YJdARIRqqCBCy3GVYdA": {
-    "title": "Statistics, CLT",
+    "title": "Estadística, TLC",
     "description": "",
     "links": [
       {
-        "title": "Introduction to Statistics",
+        "title": "Introducción a la Estadística",
         "url": "https://imp.i384100.net/3eRv4v",
         "type": "article"
       }
     ]
   },
   "XJXIkWVDIrPJ-bVIvX0ZO": {
-    "title": "Hypothesis Testing",
+    "title": "Prueba de Hipótesis",
     "description": "",
     "links": [
       {
-        "title": "Introduction to Statistical Analysis: Hypothesis Testing",
+        "title": "Introducción al Análisis Estadístico: Prueba de Hipótesis",
         "url": "https://imp.i384100.net/vN0JAA",
         "type": "article"
       },
       {
-        "title": "Explore top posts about Testing",
+        "title": "Explora las mejores publicaciones sobre Pruebas",
         "url": "https://app.daily.dev/tags/testing?ref=roadmapsh",
         "type": "article"
       }
     ]
   },
   "jxJtwbiCvxHqmkWkE7zdx": {
-    "title": "Probability and Sampling",
+    "title": "Probabilidad y Muestreo",
     "description": "",
     "links": [
       {
-        "title": "Probability and Statistics: To p or not to p?",
+        "title": "Probabilidad y Estadística: ¿Ser o no ser p?",
         "url": "https://imp.i384100.net/daDM6Q",
         "type": "article"
       },
       {
-        "title": "Explore top posts about Statistics",
+        "title": "Explora las mejores publicaciones sobre Estadística",
         "url": "https://app.daily.dev/tags/statistics?ref=roadmapsh",
         "type": "article"
       }
     ]
   },
   "mJq9b50MJM9o9dLhx40iN": {
-    "title": "AB Testing",
+    "title": "Pruebas A/B",
     "description": "",
     "links": [
       {
-        "title": "Practitioner’s Guide to Statistical Tests",
+        "title": "Guía Práctica de Pruebas Estadísticas",
         "url": "https://vkteam.medium.com/practitioners-guide-to-statistical-tests-ed2d580ef04f#1e3b",
         "type": "article"
       },
       {
-        "title": "Step by Step Process for Planning an A/B Test",
+        "title": "Proceso Paso a Paso para Planificar una Prueba A/B",
         "url": "https://medium.com/data-science/step-by-step-for-planning-an-a-b-test-ef3c93143c0b",
         "type": "article"
       },
       {
-        "title": "Explore top posts about A/B Testing",
+        "title": "Explora las mejores publicaciones sobre Pruebas A/B",
         "url": "https://app.daily.dev/tags/ab-testing?ref=roadmapsh",
         "type": "article"
       }
     ]
   },
   "v68nwX914qCwHDSwY_ZhG": {
-    "title": "Increasing Test Sensitivity",
+    "title": "Aumento de la Sensibilidad de las Pruebas",
     "description": "",
     "links": [
       {
-        "title": "Minimum Detectable Effect (MDE)",
+        "title": "Efecto Mínimo Detectable (MDE)",
         "url": "https://splitmetrics.com/resources/minimum-detectable-effect-mde/",
         "type": "article"
       },
       {
-        "title": "Improving the Sensitivity of Online Controlled Experiments: Case Studies at Netflix",
+        "title": "Mejora de la Sensibilidad de los Experimentos Controlados en Línea: Casos de Estudio en Netflix",
         "url": "https://kdd.org/kdd2016/papers/files/adp0945-xieA.pdf",
         "type": "article"
       },
       {
-        "title": "Improving the Sensitivity of Online Controlled Experiments by Utilizing Pre-Experiment Data",
+        "title": "Mejora de la Sensibilidad de los Experimentos Controlados en Línea Mediante la Utilización de Datos Previos al Experimento",
         "url": "https://exp-platform.com/Documents/2013-02-CUPED-ImprovingSensitivityOfControlledExperiments.pdf",
         "type": "article"
       },
       {
-        "title": "How Booking.com increases the power of online experiments with CUPED",
+        "title": "Cómo Booking.com aumenta la potencia de los experimentos en línea con CUPED",
         "url": "https://booking.ai/how-booking-com-increases-the-power-of-online-experiments-with-cuped-995d186fff1d",
         "type": "article"
       },
       {
-        "title": "Improving Experimental Power through Control Using Predictions as Covariate — CUPAC",
+        "title": "Mejora de la Potencia Experimental mediante el Control Usando Predicciones como Covariable — CUPAC",
         "url": "https://doordash.engineering/2020/06/08/improving-experimental-power-through-control-using-predictions-as-covariate-cupac/",
         "type": "article"
       },
       {
-        "title": "Improving the Sensitivity of Online Controlled Experiments: Case Studies at Netflix",
+        "title": "Mejora de la Sensibilidad de los Experimentos Controlados en Línea: Casos de Estudio en Netflix",
         "url": "https://www.researchgate.net/publication/305997925_Improving_the_Sensitivity_of_Online_Controlled_Experiments_Case_Studies_at_Netflix",
         "type": "article"
       }
     ]
   },
   "n2JFGwFxTuOviW6kHO1Uv": {
-    "title": "Ratio Metrics",
+    "title": "Métricas de Ratio",
     "description": "",
     "links": [
       {
-        "title": "Applying the Delta Method in Metric Analytics: A Practical Guide with Novel Ideas",
+        "title": "Aplicación del Método Delta en el Análisis de Métricas: Una Guía Práctica con Ideas Novedosas",
         "url": "https://arxiv.org/pdf/1803.06336.pdf",
         "type": "article"
       },
       {
-        "title": "Approximations for Mean and Variance of a Ratio",
+        "title": "Aproximaciones para la Media y la Varianza de un Ratio",
         "url": "https://www.stat.cmu.edu/~hseltman/files/ratio.pdf",
         "type": "article"
       }
     ]
   },
   "Gd2egqKZPnbPW1W2jw4j8": {
-    "title": "Econometrics",
-    "description": "Econometrics is the application of statistical methods to economic data. It is a branch of economics that aims to give empirical content to economic relations. More precisely, it is \"the quantitative analysis of actual economic phenomena based on the concurrent development of theory and observation, related by appropriate methods of inference.\" Econometrics can be described as something that allows economists \"to sift through mountains of data to extract simple relationships.\"",
+    "title": "Econometría",
+    "description": "La econometría es la aplicación de métodos estadísticos a datos económicos. Es una rama de la economía que tiene como objetivo dar contenido empírico a las relaciones económicas. Más precisamente, es \"el análisis cuantitativo de fenómenos económicos reales basado en el desarrollo concurrente de la teoría y la observación, relacionados mediante métodos apropiados de inferencia\". La econometría puede describirse como algo que permite a los economistas \"cribar montañas de datos para extraer relaciones simples\".",
     "links": []
   },
   "y6xXsc-uSAmRDnNuyhqH2": {
-    "title": "Pre-requisites of Econometrics",
+    "title": "Prerrequisitos de Econometría",
     "description": "",
     "links": [
       {
-        "title": "10 Fundamental Theorems for Econometrics",
+        "title": "10 Teoremas Fundamentales para la Econometría",
         "url": "https://bookdown.org/ts_robinson1994/10EconometricTheorems/",
         "type": "article"
       }
     ]
   },
   "h19k9Fn5XPh3_pKEC8Ftp": {
-    "title": "Regression, Timeseries, Fitting Distributions",
+    "title": "Regresión, Series Temporales, Ajuste de Distribuciones",
     "description": "",
     "links": [
       {
-        "title": "Blockchain.com Data Scientist TakeHome Test",
+        "title": "Prueba para Llevar a Casa de Científico de Datos de Blockchain.com",
         "url": "https://github.com/stalkermustang/bcdc_ds_takehome",
         "type": "opensource"
       },
       {
-        "title": "10 Fundamental Theorems for Econometrics",
+        "title": "10 Teoremas Fundamentales para la Econometría",
         "url": "https://bookdown.org/ts_robinson1994/10EconometricTheorems/",
         "type": "article"
       },
       {
-        "title": "Dougherty Intro to Econometrics 4th edition",
+        "title": "Introducción a la Econometría de Dougherty 4ª edición",
         "url": "https://www.academia.edu/33062577/Dougherty_Intro_to_Econometrics_4th_ed_small",
         "type": "article"
       },
       {
-        "title": "Econometrics: Methods and Applications",
+        "title": "Econometría: Métodos y Aplicaciones",
         "url": "https://imp.i384100.net/k0krYL",
         "type": "article"
       },
       {
-        "title": "Kaggle - Learn Time Series",
+        "title": "Kaggle - Aprende Series Temporales",
         "url": "https://www.kaggle.com/learn/time-series",
         "type": "article"
       },
       {
-        "title": "Time series Basics : Exploring traditional TS",
+        "title": "Conceptos Básicos de Series Temporales: Explorando las ST tradicionales",
         "url": "https://www.kaggle.com/code/jagangupta/time-series-basics-exploring-traditional-ts#Hierarchical-time-series",
         "type": "article"
       },
       {
-        "title": "How to Create an ARIMA Model for Time Series Forecasting in Python",
+        "title": "Cómo Crear un Modelo ARIMA para la Predicción de Series Temporales en Python",
         "url": "https://machinelearningmastery.com/arima-for-time-series-forecasting-with-python",
         "type": "article"
       },
       {
-        "title": "11 Classical Time Series Forecasting Methods in Python",
+        "title": "11 Métodos Clásicos de Predicción de Series Temporales en Python",
         "url": "https://machinelearningmastery.com/time-series-forecasting-methods-in-python-cheat-sheet/",
         "type": "article"
       },
       {
-        "title": "Linear Regression for Business Statistics",
+        "title": "Regresión Lineal para Estadísticas Empresariales",
         "url": "https://imp.i384100.net/9g97Ke",
         "type": "article"
       }
     ]
   },
   "XLDWuSt4tI4gnmqMFdpmy": {
-    "title": "Coding",
-    "description": "Programming is a fundamental skill for data scientists. You need to be able to write code to manipulate data, build models, and deploy solutions. The most common programming languages used in data science are Python and R. Python is a general-purpose programming language that is easy to learn and has a large number of libraries for data manipulation and machine learning. R is a programming language and free software environment for statistical computing and graphics. It is widely used for statistical analysis and data visualization.",
+    "title": "Codificación",
+    "description": "La programación es una habilidad fundamental para los científicos de datos. Necesitas poder escribir código para manipular datos, construir modelos e implementar soluciones. Los lenguajes de programación más comunes utilizados en la ciencia de datos son Python y R. Python es un lenguaje de programación de propósito general que es fácil de aprender y tiene una gran cantidad de bibliotecas para la manipulación de datos y el aprendizaje automático. R es un lenguaje de programación y un entorno de software gratuito para computación estadística y gráficos. Es ampliamente utilizado para el análisis estadístico y la visualización de datos.",
     "links": []
   },
   "MVrAqizgkoAs2aghN8TgV": {
-    "title": "Learn Python Programming Language",
+    "title": "Aprende el Lenguaje de Programación Python",
     "description": "",
     "links": [
       {
@@ -255,158 +255,158 @@
         "type": "article"
       },
       {
-        "title": "Google's Python Class",
+        "title": "Clase de Python de Google",
         "url": "https://developers.google.com/edu/python",
         "type": "article"
       },
       {
-        "title": "Explore top posts about Python",
+        "title": "Explora las mejores publicaciones sobre Python",
         "url": "https://app.daily.dev/tags/python?ref=roadmapsh",
         "type": "article"
       }
     ]
   },
   "StBCykpzpM4g9PRFeSNXa": {
-    "title": "Data Structures and Algorithms (Python)",
+    "title": "Estructuras de Datos y Algoritmos (Python)",
     "description": "",
     "links": [
       {
-        "title": "Learn Algorithms",
+        "title": "Aprende Algoritmos",
         "url": "https://leetcode.com/explore/learn/",
         "type": "article"
       },
       {
-        "title": "Leetcode - Study Plans",
+        "title": "Leetcode - Planes de Estudio",
         "url": "https://leetcode.com/studyplan/",
         "type": "article"
       },
       {
-        "title": "Algorithms Specialization",
+        "title": "Especialización en Algoritmos",
         "url": "https://imp.i384100.net/5gqv4n",
         "type": "article"
       }
     ]
   },
   "Im0tXXn3GC-FUq2aMHgwm": {
-    "title": "Learn SQL",
+    "title": "Aprende SQL",
     "description": "",
     "links": [
       {
-        "title": "SQL Tutorial",
+        "title": "Tutorial de SQL",
         "url": "https://www.sqltutorial.org/",
         "type": "article"
       },
       {
-        "title": "Explore top posts about SQL",
+        "title": "Explora las mejores publicaciones sobre SQL",
         "url": "https://app.daily.dev/tags/sql?ref=roadmapsh",
         "type": "article"
       }
     ]
   },
   "l1027SBZxTHKzqWw98Ee-": {
-    "title": "Exploratory Data Analysis",
-    "description": "Exploratory Data Analysis (EDA) is an approach to analyzing data sets to summarize their main characteristics, often with visual methods. EDA is used to understand what the data can tell us beyond the formal modeling or hypothesis testing task. It is a crucial step in the data analysis process.",
+    "title": "Análisis Exploratorio de Datos",
+    "description": "El Análisis Exploratorio de Datos (EDA) es un enfoque para analizar conjuntos de datos para resumir sus características principales, a menudo con métodos visuales. El EDA se utiliza para comprender qué nos pueden decir los datos más allá de la tarea formal de modelado o prueba de hipótesis. Es un paso crucial en el proceso de análisis de datos.",
     "links": []
   },
   "JaN8YhMeN3whAe2TCXvw9": {
-    "title": "Data understanding, Data Analysis and Visualization",
+    "title": "Comprensión de Datos, Análisis de Datos y Visualización",
     "description": "",
     "links": [
       {
-        "title": "Exploratory Data Analysis With Python and Pandas",
+        "title": "Análisis Exploratorio de Datos Con Python y Pandas",
         "url": "https://imp.i384100.net/AWAv4R",
         "type": "article"
       },
       {
-        "title": "Exploratory Data Analysis for Machine Learning",
+        "title": "Análisis Exploratorio de Datos para Aprendizaje Automático",
         "url": "https://imp.i384100.net/GmQMLE",
         "type": "article"
       },
       {
-        "title": "Exploratory Data Analysis with Seaborn",
+        "title": "Análisis Exploratorio de Datos con Seaborn",
         "url": "https://imp.i384100.net/ZQmMgR",
         "type": "article"
       }
     ]
   },
   "kBdt_t2SvVsY3blfubWIz": {
-    "title": "Machine Learning",
-    "description": "Machine learning is a field of artificial intelligence that uses statistical techniques to give computer systems the ability to \"learn\" (e.g., progressively improve performance on a specific task) from data, without being explicitly programmed. The name machine learning was coined in 1959 by Arthur Samuel. Evolved from the study of pattern recognition and computational learning theory in artificial intelligence, machine learning explores the study and construction of algorithms that can learn from and make predictions on data – such algorithms overcome following strictly static program instructions by making data-driven predictions or decisions, through building a model from sample inputs. Machine learning is employed in a range of computing tasks where designing and programming explicit algorithms with good performance is difficult or infeasible; example applications include email filtering, detection of network intruders, and computer vision.\n\nLearn more from the following resources:",
+    "title": "Aprendizaje Automático",
+    "description": "El aprendizaje automático es un campo de la inteligencia artificial que utiliza técnicas estadísticas para dar a los sistemas informáticos la capacidad de \"aprender\" (por ejemplo, mejorar progresivamente el rendimiento en una tarea específica) a partir de los datos, sin ser programados explícitamente. El nombre de aprendizaje automático fue acuñado en 1959 por Arthur Samuel. Evolucionado a partir del estudio del reconocimiento de patrones y la teoría del aprendizaje computacional en inteligencia artificial, el aprendizaje automático explora el estudio y la construcción de algoritmos que pueden aprender de los datos y hacer predicciones sobre ellos; dichos algoritmos superan el seguimiento de instrucciones de programas estrictamente estáticos al realizar predicciones o decisiones basadas en datos, mediante la construcción de un modelo a partir de entradas de muestra. El aprendizaje automático se emplea en una variedad de tareas informáticas donde diseñar y programar algoritmos explícitos con buen rendimiento es difícil o inviable; ejemplos de aplicaciones incluyen el filtrado de correo electrónico, la detección de intrusos en la red y la visión por computadora.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
-        "title": "Advantages and Disadvantages of AI",
+        "title": "Ventajas y Desventajas de la IA",
         "url": "https://medium.com/@laners.org/advantages-and-disadvantages-of-artificial-intelligence-cd6e42819b20",
         "type": "article"
       },
       {
-        "title": "Reinforcement Learning 101",
+        "title": "Aprendizaje por Refuerzo 101",
         "url": "https://medium.com/towards-data-science/reinforcement-learning-101-e24b50e1d292",
         "type": "article"
       },
       {
-        "title": "Understanding AUC-ROC Curve",
+        "title": "Comprendiendo la Curva AUC-ROC",
         "url": "https://medium.com/towards-data-science/understanding-auc-roc-curve-68b2303cc9c5",
         "type": "article"
       }
     ]
   },
   "FdBih8tlGPPy97YWq463y": {
-    "title": "Classic ML (Sup., Unsup.), Advanced ML (Ensembles, NNs)",
+    "title": "AA Clásico (Sup., No Sup.), AA Avanzado (Ensambles, RN)",
     "description": "",
     "links": [
       {
-        "title": "Repository of notes, code and notebooks in Python for the book Pattern Recognition and Machine Learning by Christopher Bishop",
+        "title": "Repositorio de notas, código y cuadernos en Python para el libro Pattern Recognition and Machine Learning de Christopher Bishop",
         "url": "https://github.com/gerdm/prml",
         "type": "opensource"
       },
       {
-        "title": "Open Machine Learning Course",
+        "title": "Curso Abierto de Aprendizaje Automático",
         "url": "https://mlcourse.ai/book/topic01/topic01_intro.html",
         "type": "article"
       },
       {
-        "title": "Coursera: Machine Learning Specialization",
+        "title": "Coursera: Especialización en Aprendizaje Automático",
         "url": "https://imp.i384100.net/oqGkrg",
         "type": "article"
       },
       {
-        "title": "Pattern Recognition and Machine Learning by Christopher Bishop",
+        "title": "Pattern Recognition and Machine Learning por Christopher Bishop",
         "url": "https://www.microsoft.com/en-us/research/uploads/prod/2006/01/Bishop-Pattern-Recognition-and-Machine-Learning-2006.pdf",
         "type": "article"
       },
       {
-        "title": "Explore top posts about Machine Learning",
+        "title": "Explora las mejores publicaciones sobre Aprendizaje Automático",
         "url": "https://app.daily.dev/tags/machine-learning?ref=roadmapsh",
         "type": "article"
       }
     ]
   },
   "cjvVLN0XjrKPn6o20oMmc": {
-    "title": "Deep Learning",
-    "description": "Deep Learning\n-------------\n\nDeep learning is a subset of machine learning that deals with algorithms inspired by the structure and function of the brain called artificial neural networks. Deep learning is a key technology behind driverless cars, enabling them to recognize a stop sign, or to distinguish a pedestrian from a lamppost. It is the key to voice control in consumer devices like phones, tablets, TVs, and hands-free speakers. Deep learning is getting lots of attention lately and for good reason. It’s achieving results that were not possible before.",
+    "title": "Aprendizaje Profundo",
+    "description": "Aprendizaje Profundo\n-------------\n\nEl aprendizaje profundo es un subconjunto del aprendizaje automático que se ocupa de algoritmos inspirados en la estructura y función del cerebro llamados redes neuronales artificiales. El aprendizaje profundo es una tecnología clave detrás de los coches sin conductor, permitiéndoles reconocer una señal de alto o distinguir un peatón de una farola. Es la clave para el control por voz en dispositivos de consumo como teléfonos, tabletas, televisores y altavoces manos libres. El aprendizaje profundo está recibiendo mucha atención últimamente y por una buena razón. Está logrando resultados que antes no eran posibles.",
     "links": []
   },
   "eOFoGKveaHaBm_6ppJUtA": {
-    "title": "Fully Connected, CNN, RNN, LSTM, Transformers, TL",
+    "title": "Totalmente Conectadas, CNN, RNN, LSTM, Transformers, TL",
     "description": "",
     "links": [
       {
-        "title": "The Illustrated Transformer",
+        "title": "El Transformer Ilustrado",
         "url": "https://jalammar.github.io/illustrated-transformer/",
         "type": "article"
       },
       {
-        "title": "Attention is All you Need",
+        "title": "La Atención es Todo lo que Necesitas",
         "url": "https://arxiv.org/pdf/1706.03762.pdf",
         "type": "article"
       },
       {
-        "title": "Deep Learning Book",
+        "title": "Libro de Aprendizaje Profundo",
         "url": "https://www.deeplearningbook.org/",
         "type": "article"
       },
       {
-        "title": "Deep Learning Specialization",
+        "title": "Especialización en Aprendizaje Profundo",
         "url": "https://imp.i384100.net/Wq9MV3",
         "type": "article"
       }
@@ -414,25 +414,25 @@
   },
   "Qa85hEVe2kz62k9Pj4QCA": {
     "title": "MLOps",
-    "description": "MLOps is a practice for collaboration and communication between data scientists and operations professionals to help manage production ML lifecycle. It is a set of best practices that aims to automate the ML lifecycle, including training, deployment, and monitoring. MLOps helps organizations to scale ML models and deliver business value faster.",
+    "description": "MLOps es una práctica de colaboración y comunicación entre científicos de datos y profesionales de operaciones para ayudar a gestionar el ciclo de vida de ML en producción. Es un conjunto de mejores prácticas que tiene como objetivo automatizar el ciclo de vida de ML, incluido el entrenamiento, la implementación y el monitoreo. MLOps ayuda a las organizaciones a escalar modelos de ML y ofrecer valor comercial más rápido.",
     "links": []
   },
   "uPzzUpI0--7OWDfNeBIjt": {
-    "title": "Deployment Models, CI/CD",
+    "title": "Modelos de Implementación, CI/CD",
     "description": "",
     "links": [
       {
-        "title": "Machine Learning Engineering for Production (MLOps) Specialization",
+        "title": "Especialización en Ingeniería de Aprendizaje Automático para Producción (MLOps)",
         "url": "https://imp.i384100.net/nLA5mx",
         "type": "article"
       },
       {
-        "title": "Full Stack Deep Learning",
+        "title": "Aprendizaje Profundo Full Stack",
         "url": "https://fullstackdeeplearning.com/course/2022/",
         "type": "article"
       },
       {
-        "title": "Explore top posts about CI/CD",
+        "title": "Explora las mejores publicaciones sobre CI/CD",
         "url": "https://app.daily.dev/tags/cicd?ref=roadmapsh",
         "type": "article"
       }

--- a/public/roadmap-content/ai-engineer.json
+++ b/public/roadmap-content/ai-engineer.json
@@ -1,57 +1,57 @@
 {
   "_hYN0gEi9BL24nptEtXWU": {
-    "title": "Introduction",
-    "description": "AI Engineering is the process of designing and implementing AI systems using pre-trained models and existing AI tools to solve practical problems. AI Engineers focus on applying AI in real-world scenarios, improving user experiences, and automating tasks, without developing new models from scratch. They work to ensure AI systems are efficient, scalable, and can be seamlessly integrated into business applications, distinguishing their role from AI Researchers and ML Engineers, who concentrate more on creating new models or advancing AI theory.\n\nLearn more from the following resources:",
+    "title": "Introducción",
+    "description": "La Ingeniería de IA es el proceso de diseñar e implementar sistemas de IA utilizando modelos preentrenados y herramientas de IA existentes para resolver problemas prácticos. Los ingenieros de IA se centran en aplicar la IA en escenarios del mundo real, mejorar las experiencias de los usuarios y automatizar tareas, sin desarrollar nuevos modelos desde cero. Trabajan para garantizar que los sistemas de IA sean eficientes, escalables y puedan integrarse sin problemas en las aplicaciones empresariales, lo que distingue su función de la de los investigadores de IA y los ingenieros de ML, que se concentran más en crear nuevos modelos o avanzar en la teoría de la IA.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
-        "title": "AI Engineering",
+        "title": "Ingeniería de IA",
         "url": "https://en.wikipedia.org/wiki/Artificial_intelligence_engineering",
         "type": "article"
       },
       {
-        "title": "AI vs Machine Learning",
+        "title": "IA vs Aprendizaje Automático",
         "url": "https://www.youtube.com/watch?v=4RixMPF4xis",
         "type": "video"
       }
     ]
   },
   "GN6SnI7RXIeW8JeD-qORW": {
-    "title": "What is an AI Engineer?",
-    "description": "AI engineers are professionals who specialize in designing, developing, and implementing artificial intelligence (AI) systems. Their work is essential in various industries, as they create applications that enable machines to perform tasks that typically require human intelligence, such as problem-solving, learning, and decision-making.\n\nVisit the following resources to learn more:",
+    "title": "¿Qué es un Ingeniero de IA?",
+    "description": "Los ingenieros de IA son profesionales que se especializan en diseñar, desarrollar e implementar sistemas de inteligencia artificial (IA). Su trabajo es esencial en diversas industrias, ya que crean aplicaciones que permiten a las máquinas realizar tareas que normalmente requieren inteligencia humana, como la resolución de problemas, el aprendizaje y la toma de decisiones.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "AI For Everyone",
+        "title": "IA para Todos",
         "url": "https://www.coursera.org/learn/ai-for-everyone",
         "type": "course"
       },
       {
-        "title": "How to Become an AI Engineer: Duties, Skills, and Salary",
+        "title": "Cómo Convertirse en un Ingeniero de IA: Deberes, Habilidades y Salario",
         "url": "https://www.simplilearn.com/tutorials/artificial-intelligence-tutorial/how-to-become-an-ai-engineer",
         "type": "article"
       },
       {
-        "title": "AI Engineers: What they do and how to become one",
+        "title": "Ingenieros de IA: Qué hacen y cómo convertirse en uno",
         "url": "https://www.techtarget.com/whatis/feature/How-to-become-an-artificial-intelligence-engineer",
         "type": "article"
       }
     ]
   },
   "jSZ1LhPdhlkW-9QJhIvFs": {
-    "title": "AI Engineer vs ML Engineer",
-    "description": "An AI Engineer uses pre-trained models and existing AI tools to improve user experiences. They focus on applying AI in practical ways, without building models from scratch. This is different from AI Researchers and ML Engineers, who focus more on creating new models or developing AI theory.\n\nLearn more from the following resources:",
+    "title": "Ingeniero de IA vs Ingeniero de ML",
+    "description": "Un Ingeniero de IA utiliza modelos preentrenados y herramientas de IA existentes para mejorar las experiencias de los usuarios. Se centran en aplicar la IA de formas prácticas, sin construir modelos desde cero. Esto es diferente de los Investigadores de IA y los Ingenieros de ML, que se centran más en crear nuevos modelos o desarrollar la teoría de la IA.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
-        "title": "What does an AI Engineer do?",
+        "title": "¿Qué hace un Ingeniero de IA?",
         "url": "https://www.codecademy.com/resources/blog/what-does-an-ai-engineer-do/",
         "type": "article"
       },
       {
-        "title": "What is an ML Engineer?",
+        "title": "¿Qué es un Ingeniero de ML?",
         "url": "https://www.coursera.org/articles/what-is-machine-learning-engineer",
         "type": "article"
       },
       {
-        "title": "AI vs ML",
+        "title": "IA vs ML",
         "url": "https://www.youtube.com/watch?v=4RixMPF4xis",
         "type": "video"
       }
@@ -59,62 +59,62 @@
   },
   "wf2BSyUekr1S1q6l8kyq6": {
     "title": "LLMs",
-    "description": "LLMs, or Large Language Models, are advanced AI models trained on vast datasets to understand and generate human-like text. They can perform a wide range of natural language processing tasks, such as text generation, translation, summarization, and question answering. Examples include GPT-4, BERT, and T5. LLMs are capable of understanding context, handling complex queries, and generating coherent responses, making them useful for applications like chatbots, content creation, and automated support. However, they require significant computational resources and may carry biases from their training data.\n\nLearn more from the following resources:",
+    "description": "Los LLM, o Modelos de Lenguaje Grandes, son modelos avanzados de IA entrenados en vastos conjuntos de datos para comprender y generar texto similar al humano. Pueden realizar una amplia gama de tareas de procesamiento del lenguaje natural, como generación de texto, traducción, resumen y respuesta a preguntas. Ejemplos incluyen GPT-4, BERT y T5. Los LLM son capaces de comprender el contexto, manejar consultas complejas y generar respuestas coherentes, lo que los hace útiles para aplicaciones como chatbots, creación de contenido y soporte automatizado. Sin embargo, requieren importantes recursos computacionales y pueden contener sesgos de sus datos de entrenamiento.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
-        "title": "What is a large language model (LLM)?",
+        "title": "¿Qué es un modelo de lenguaje grande (LLM)?",
         "url": "https://www.cloudflare.com/en-gb/learning/ai/what-is-large-language-model/",
         "type": "article"
       },
       {
-        "title": "How Large Language Models Work",
+        "title": "Cómo Funcionan los Modelos de Lenguaje Grandes",
         "url": "https://www.youtube.com/watch?v=5sLYAQS9sWQ",
         "type": "video"
       },
       {
-        "title": "Large Language Models (LLMs) - Everything You NEED To Know",
+        "title": "Modelos de Lenguaje Grandes (LLMs) - Todo lo que NECESITAS Saber",
         "url": "https://www.youtube.com/watch?v=osKyvYJ3PRM",
         "type": "video"
       }
     ]
   },
   "KWjD4xEPhOOYS51dvRLd2": {
-    "title": "Inference",
-    "description": "In artificial intelligence (AI), inference refers to the process where a trained machine learning model makes predictions or draws conclusions from new, unseen data. Unlike training, inference involves the model applying what it has learned to make decisions without needing examples of the exact result. In essence, inference is the AI model actively functioning. For example, a self-driving car recognizing a stop sign on a road it has never encountered before demonstrates inference. The model identifies the stop sign in a new setting, using its learned knowledge to make a decision in real-time.\n\nLearn more from the following resources:",
+    "title": "Inferencia",
+    "description": "En inteligencia artificial (IA), la inferencia se refiere al proceso mediante el cual un modelo de aprendizaje automático entrenado realiza predicciones o extrae conclusiones a partir de datos nuevos y no vistos. A diferencia del entrenamiento, la inferencia implica que el modelo aplique lo que ha aprendido para tomar decisiones sin necesitar ejemplos del resultado exacto. En esencia, la inferencia es el modelo de IA funcionando activamente. Por ejemplo, un coche autónomo que reconoce una señal de alto en una carretera que nunca antes ha encontrado demuestra la inferencia. El modelo identifica la señal de alto en un nuevo entorno, utilizando su conocimiento aprendido para tomar una decisión en tiempo real.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
-        "title": "Inference vs Training",
+        "title": "Inferencia vs Entrenamiento",
         "url": "https://www.cloudflare.com/learning/ai/inference-vs-training/",
         "type": "article"
       },
       {
-        "title": "What is Machine Learning Inference?",
+        "title": "¿Qué es la Inferencia en el Aprendizaje Automático?",
         "url": "https://hazelcast.com/glossary/machine-learning-inference/",
         "type": "article"
       },
       {
-        "title": "What is Machine Learning Inference? An Introduction to Inference Approaches",
+        "title": "¿Qué es la Inferencia en el Aprendizaje Automático? Una Introducción a los Enfoques de Inferencia",
         "url": "https://www.datacamp.com/blog/what-is-machine-learning-inference",
         "type": "article"
       }
     ]
   },
   "xostGgoaYkqMO28iN2gx8": {
-    "title": "Training",
-    "description": "Training refers to the process of teaching a machine learning model to recognize patterns and make predictions by exposing it to a dataset. During training, the model learns from the data by adjusting its internal parameters to minimize errors between its predictions and the actual outcomes. This process involves iteratively feeding the model with input data, comparing its outputs to the correct answers, and refining its predictions through techniques like gradient descent. The goal is to enable the model to generalize well so that it can make accurate predictions on new, unseen data.\n\nLearn more from the following resources:",
+    "title": "Entrenamiento",
+    "description": "El entrenamiento se refiere al proceso de enseñar a un modelo de aprendizaje automático a reconocer patrones y realizar predicciones exponiéndolo a un conjunto de datos. Durante el entrenamiento, el modelo aprende de los datos ajustando sus parámetros internos para minimizar los errores entre sus predicciones y los resultados reales. Este proceso implica alimentar iterativamente al modelo con datos de entrada, comparar sus salidas con las respuestas correctas y refinar sus predicciones mediante técnicas como el descenso de gradiente. El objetivo es permitir que el modelo generalice bien para que pueda realizar predicciones precisas sobre datos nuevos y no vistos.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
-        "title": "What is Model Training?",
+        "title": "¿Qué es el Entrenamiento de Modelos?",
         "url": "https://oden.io/glossary/model-training/",
         "type": "article"
       },
       {
-        "title": "Machine learning model training: What it is and why it’s important",
+        "title": "Entrenamiento de modelos de aprendizaje automático: Qué es y por qué es importante",
         "url": "https://domino.ai/blog/what-is-machine-learning-model-training",
         "type": "article"
       },
       {
-        "title": "Training ML Models - Amazon",
+        "title": "Entrenamiento de Modelos de ML - Amazon",
         "url": "https://docs.aws.amazon.com/machine-learning/latest/dg/training-ml-models.html",
         "type": "article"
       }
@@ -122,36 +122,36 @@
   },
   "XyEp6jnBSpCxMGwALnYfT": {
     "title": "Embeddings",
-    "description": "Embeddings are dense, continuous vector representations of data, such as words, sentences, or images, in a lower-dimensional space. They capture the semantic relationships and patterns in the data, where similar items are placed closer together in the vector space. In machine learning, embeddings are used to convert complex data into numerical form that models can process more easily. For example, word embeddings represent words based on their meanings and contexts, allowing models to understand relationships like synonyms or analogies. Embeddings are widely used in tasks like natural language processing, recommendation systems, and image recognition to improve model performance and efficiency.\n\nLearn more from the following resources:",
+    "description": "Los embeddings son representaciones vectoriales densas y continuas de datos, como palabras, oraciones o imágenes, en un espacio de menor dimensión. Capturan las relaciones semánticas y los patrones en los datos, donde los elementos similares se colocan más cerca en el espacio vectorial. En el aprendizaje automático, los embeddings se utilizan para convertir datos complejos en forma numérica que los modelos pueden procesar más fácilmente. Por ejemplo, los embeddings de palabras representan palabras basadas en sus significados y contextos, lo que permite a los modelos comprender relaciones como sinónimos o analogías. Los embeddings se utilizan ampliamente en tareas como el procesamiento del lenguaje natural, los sistemas de recomendación y el reconocimiento de imágenes para mejorar el rendimiento y la eficiencia del modelo.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
-        "title": "What are Embeddings in Machine Learning?",
+        "title": "¿Qué son los Embeddings en el Aprendizaje Automático?",
         "url": "https://www.cloudflare.com/en-gb/learning/ai/what-are-embeddings/",
         "type": "article"
       },
       {
-        "title": "What is Embedding?",
+        "title": "¿Qué es un Embedding?",
         "url": "https://www.ibm.com/topics/embedding",
         "type": "article"
       },
       {
-        "title": "What are Word Embeddings",
+        "title": "¿Qué son los Embeddings de Palabras?",
         "url": "https://www.youtube.com/watch?v=wgfSDrqYMJ4",
         "type": "video"
       }
     ]
   },
   "LnQ2AatMWpExUHcZhDIPd": {
-    "title": "Vector Databases",
-    "description": "Vector databases are specialized systems designed to store, index, and retrieve high-dimensional vectors, often used as embeddings that represent data like text, images, or audio. Unlike traditional databases that handle structured data, vector databases excel at managing unstructured data by enabling fast similarity searches, where vectors are compared to find those that are most similar to a query. This makes them essential for tasks like semantic search, recommendation systems, and content discovery, where understanding relationships between items is crucial. Vector databases use indexing techniques such as approximate nearest neighbor (ANN) search to efficiently handle large datasets, ensuring quick and accurate retrieval even at scale.\n\nLearn more from the following resources:",
+    "title": "Bases de Datos Vectoriales",
+    "description": "Las bases de datos vectoriales son sistemas especializados diseñados para almacenar, indexar y recuperar vectores de alta dimensión, a menudo utilizados como embeddings que representan datos como texto, imágenes o audio. A diferencia de las bases de datos tradicionales que manejan datos estructurados, las bases de datos vectoriales sobresalen en la gestión de datos no estructurados al permitir búsquedas rápidas de similitud, donde los vectores se comparan para encontrar aquellos que son más similares a una consulta. Esto las hace esenciales para tareas como la búsqueda semántica, los sistemas de recomendación y el descubrimiento de contenido, donde comprender las relaciones entre los elementos es crucial. Las bases de datos vectoriales utilizan técnicas de indexación como la búsqueda aproximada del vecino más cercano (ANN) para manejar eficientemente grandes conjuntos de datos, asegurando una recuperación rápida y precisa incluso a escala.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
-        "title": "Vector Databases",
+        "title": "Bases de Datos Vectoriales",
         "url": "https://developers.cloudflare.com/vectorize/reference/what-is-a-vector-database/",
         "type": "article"
       },
       {
-        "title": "What are Vector Databases?",
+        "title": "¿Qué son las Bases de Datos Vectoriales?",
         "url": "https://www.mongodb.com/resources/basics/databases/vector-databases",
         "type": "article"
       }
@@ -159,204 +159,204 @@
   },
   "9JwWIK0Z2MK8-6EQQJsCO": {
     "title": "RAG",
-    "description": "Retrieval-Augmented Generation (RAG) is an AI approach that combines information retrieval with language generation to create more accurate, contextually relevant outputs. It works by first retrieving relevant data from a knowledge base or external source, then using a language model to generate a response based on that information. This method enhances the accuracy of generative models by grounding their outputs in real-world data, making RAG ideal for tasks like question answering, summarization, and chatbots that require reliable, up-to-date information.\n\nLearn more from the following resources:",
+    "description": "La Generación Aumentada por Recuperación (RAG) es un enfoque de IA que combina la recuperación de información con la generación de lenguaje para crear resultados más precisos y contextualmente relevantes. Funciona recuperando primero datos relevantes de una base de conocimientos o fuente externa, y luego utilizando un modelo de lenguaje para generar una respuesta basada en esa información. Este método mejora la precisión de los modelos generativos al basar sus resultados en datos del mundo real, lo que hace que RAG sea ideal para tareas como respuesta a preguntas, resumen y chatbots que requieren información confiable y actualizada.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
-        "title": "What is Retrieval Augmented Generation (RAG)? - Datacamp",
+        "title": "¿Qué es la Generación Aumentada por Recuperación (RAG)? - Datacamp",
         "url": "https://www.datacamp.com/blog/what-is-retrieval-augmented-generation-rag",
         "type": "article"
       },
       {
-        "title": "What is Retrieval-Augmented Generation? - Google",
+        "title": "¿Qué es la Generación Aumentada por Recuperación? - Google",
         "url": "https://cloud.google.com/use-cases/retrieval-augmented-generation",
         "type": "article"
       },
       {
-        "title": "What is Retrieval-Augmented Generation? - IBM",
+        "title": "¿Qué es la Generación Aumentada por Recuperación? - IBM",
         "url": "https://www.youtube.com/watch?v=T-D1OfcDW1M",
         "type": "video"
       }
     ]
   },
   "Dc15ayFlzqMF24RqIF_-X": {
-    "title": "Prompt Engineering",
-    "description": "Prompt engineering is the process of crafting effective inputs (prompts) to guide AI models, like GPT, to generate desired outputs. It involves strategically designing prompts to optimize the model’s performance by providing clear instructions, context, and examples. Effective prompt engineering can improve the quality, relevance, and accuracy of responses, making it essential for applications like chatbots, content generation, and automated support. By refining prompts, developers can better control the model’s behavior, reduce ambiguity, and achieve more consistent results, enhancing the overall effectiveness of AI-driven systems.\n\nLearn more from the following resources:",
+    "title": "Ingeniería de Prompts",
+    "description": "La ingeniería de prompts es el proceso de elaborar entradas efectivas (prompts) para guiar a los modelos de IA, como GPT, a generar las salidas deseadas. Implica diseñar estratégicamente los prompts para optimizar el rendimiento del modelo proporcionando instrucciones claras, contexto y ejemplos. Una ingeniería de prompts eficaz puede mejorar la calidad, relevancia y precisión de las respuestas, lo que la hace esencial para aplicaciones como chatbots, generación de contenido y soporte automatizado. Al refinar los prompts, los desarrolladores pueden controlar mejor el comportamiento del modelo, reducir la ambigüedad y lograr resultados más consistentes, mejorando la efectividad general de los sistemas impulsados por IA.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
-        "title": "Visit Dedicated Prompt Engineering Roadmap",
+        "title": "Visita el Roadmap Dedicado de Ingeniería de Prompts",
         "url": "https://roadmap.sh/prompt-engineering",
         "type": "article"
       },
       {
-        "title": "What is Prompt Engineering?",
+        "title": "¿Qué es la Ingeniería de Prompts?",
         "url": "https://www.youtube.com/watch?v=nf1e-55KKbg",
         "type": "video"
       }
     ]
   },
   "9XCxilAQ7FRet7lHQr1gE": {
-    "title": "AI Agents",
-    "description": "In AI engineering, \"agents\" refer to autonomous systems or components that can perceive their environment, make decisions, and take actions to achieve specific goals. Agents often interact with external systems, users, or other agents to carry out complex tasks. They can vary in complexity, from simple rule-based bots to sophisticated AI-powered agents that leverage machine learning models, natural language processing, and reinforcement learning.\n\nVisit the following resources to learn more:",
+    "title": "Agentes de IA",
+    "description": "En la ingeniería de IA, los \"agentes\" se refieren a sistemas o componentes autónomos que pueden percibir su entorno, tomar decisiones y realizar acciones para alcanzar objetivos específicos. Los agentes a menudo interactúan con sistemas externos, usuarios u otros agentes para llevar a cabo tareas complejas. Pueden variar en complejidad, desde simples bots basados en reglas hasta sofisticados agentes impulsados por IA que aprovechan modelos de aprendizaje automático, procesamiento del lenguaje natural y aprendizaje por refuerzo.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "Building an AI Agent Tutorial - LangChain",
+        "title": "Tutorial para Construir un Agente de IA - LangChain",
         "url": "https://python.langchain.com/docs/tutorials/agents/",
         "type": "article"
       },
       {
-        "title": "AI Agents and Their Types",
+        "title": "Agentes de IA y sus Tipos",
         "url": "https://play.ht/blog/ai-agents-use-cases/",
         "type": "article"
       },
       {
-        "title": "The Complete Guide to Building AI Agents for Beginners",
+        "title": "La Guía Completa para Construir Agentes de IA para Principiantes",
         "url": "https://youtu.be/MOyl58VF2ak?si=-QjRD_5y3iViprJX",
         "type": "video"
       }
     ]
   },
   "5QdihE1lLpMc3DFrGy46M": {
-    "title": "AI vs AGI",
-    "description": "AI (Artificial Intelligence) refers to systems designed to perform specific tasks by mimicking aspects of human intelligence, such as pattern recognition, decision-making, and language processing. These systems, known as \"narrow AI,\" are highly specialized, excelling in defined areas like image classification or recommendation algorithms but lacking broader cognitive abilities. In contrast, AGI (Artificial General Intelligence) represents a theoretical form of intelligence that possesses the ability to understand, learn, and apply knowledge across a wide range of tasks at a human-like level. AGI would have the capacity for abstract thinking, reasoning, and adaptability similar to human cognitive abilities, making it far more versatile than today’s AI systems. While current AI technology is powerful, AGI remains a distant goal and presents complex challenges in safety, ethics, and technical feasibility.\n\nLearn more from the following resources:",
+    "title": "IA vs IAG",
+    "description": "IA (Inteligencia Artificial) se refiere a sistemas diseñados para realizar tareas específicas imitando aspectos de la inteligencia humana, como el reconocimiento de patrones, la toma de decisiones y el procesamiento del lenguaje. Estes sistemas, conocidos como \"IA estrecha\", son altamente especializados, sobresaliendo en áreas definidas como la clasificación de imágenes o los algoritmos de recomendación, pero carecen de habilidades cognitivas más amplias. En contraste, IAG (Inteligencia Artificial General) representa una forma teórica de inteligencia que posee la capacidad de comprender, aprender y aplicar conocimientos en una amplia gama de tareas a un nivel similar al humano. La IAG tendría la capacidad de pensamiento abstracto, razonamiento y adaptabilidad similares a las habilidades cognitivas humanas, lo que la haría mucho más versátil que los sistemas de IA actuales. Si bien la tecnología de IA actual es poderosa, la IAG sigue siendo un objetivo lejano y presenta desafíos complejos en seguridad, ética y viabilidad técnica.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
-        "title": "What is AGI?",
+        "title": "¿Qué es la IAG?",
         "url": "https://aws.amazon.com/what-is/artificial-general-intelligence/",
         "type": "article"
       },
       {
-        "title": "The crucial difference between AI and AGI",
+        "title": "La diferencia crucial entre IA e IAG",
         "url": "https://www.forbes.com/sites/bernardmarr/2024/05/20/the-crucial-difference-between-ai-and-agi/",
         "type": "article"
       }
     ]
   },
   "qJVgKe9uBvXc-YPfvX_Y7": {
-    "title": "Impact on Product Development",
-    "description": "AI engineering transforms product development by automating tasks, enhancing data-driven decision-making, and enabling the creation of smarter, more personalized products. It speeds up design cycles, optimizes processes, and allows for predictive maintenance, quality control, and efficient resource management. By integrating AI, companies can innovate faster, reduce costs, and improve user experiences, giving them a competitive edge in the market.\n\nLearn more from the following resources:",
+    "title": "Impacto en el Desarrollo de Productos",
+    "description": "La ingeniería de IA transforma el desarrollo de productos al automatizar tareas, mejorar la toma de decisiones basada en datos y permitir la creación de productos más inteligentes y personalizados. Acelera los ciclos de diseño, optimiza los procesos y permite el mantenimiento predictivo, el control de calidad y la gestión eficiente de los recursos. Al integrar la IA, las empresas pueden innovar más rápido, reducir costos y mejorar las experiencias de los usuarios, lo que les otorga una ventaja competitiva en el mercado.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
-        "title": "AI in Product Development: Netflix, BMW, and PepsiCo",
+        "title": "IA en el Desarrollo de Productos: Netflix, BMW y PepsiCo",
         "url": "https://www.virtasant.com/ai-today/ai-in-product-development-netflix-bmw#:~:text=AI%20can%20help%20make%20product,and%20gain%20a%20competitive%20edge.",
         "type": "article"
       },
       {
-        "title": "AI Product Development: Why Are Founders So Fascinated By The Potential?",
+        "title": "Desarrollo de Productos de IA: ¿Por Qué los Fundadores Están Tan Fascinados por el Potencial?",
         "url": "https://www.techmagic.co/blog/ai-product-development/",
         "type": "article"
       }
     ]
   },
   "K9EiuFgPBFgeRxY4wxAmb": {
-    "title": "Roles and Responsiblities",
-    "description": "AI Engineers are responsible for designing, developing, and deploying AI systems that solve real-world problems. Their roles include building machine learning models, implementing data processing pipelines, and integrating AI solutions into existing software or platforms. They work on tasks like data collection, cleaning, and labeling, as well as model training, testing, and optimization to ensure high performance and accuracy. AI Engineers also focus on scaling models for production use, monitoring their performance, and troubleshooting issues. Additionally, they collaborate with data scientists, software developers, and other stakeholders to align AI projects with business goals, ensuring that solutions are reliable, efficient, and ethically sound.\n\nLearn more from the following resources:",
+    "title": "Roles y Responsabilidades",
+    "description": "Los Ingenieros de IA son responsables de diseñar, desarrollar e implementar sistemas de IA que resuelvan problemas del mundo real. Sus roles incluyen la construcción de modelos de aprendizaje automático, la implementación de canalizaciones de procesamiento de datos y la integración de soluciones de IA en software o plataformas existentes. Trabajan en tareas como la recopilación, limpieza y etiquetado de datos, así como el entrenamiento, prueba y optimización de modelos para garantizar un alto rendimiento y precisión. Los Ingenieros de IA también se centran en escalar modelos para uso en producción, monitorear su rendimiento y solucionar problemas. Además, colaboran con científicos de datos, desarrolladores de software y otras partes interesadas para alinear los proyectos de IA con los objetivos comerciales, asegurando que las soluciones sean confiables, eficientes y éticamente sólidas.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
-        "title": "AI Engineer Job Description",
+        "title": "Descripción del Puesto de Ingeniero de IA",
         "url": "https://resources.workable.com/ai-engineer-job-description",
         "type": "article"
       },
       {
-        "title": "How To Become an AI Engineer (Plus Job Duties and Skills)",
+        "title": "Cómo Convertirse en un Ingeniero de IA (Además de Deberes y Habilidades Laborales)",
         "url": "https://www.indeed.com/career-advice/finding-a-job/ai-engineer",
         "type": "article"
       }
     ]
   },
   "d7fzv_ft12EopsQdmEsel": {
-    "title": "Pre-trained Models",
-    "description": "Pre-trained models are Machine Learning (ML) models that have been previously trained on a large dataset to solve a specific task or set of tasks. These models learn patterns, features, and representations from the training data, which can then be fine-tuned or adapted for other related tasks. Pre-training provides a good starting point, reducing the amount of data and computation required to train a new model from scratch.\n\nVisit the following resources to learn more:",
+    "title": "Modelos Preentrenados",
+    "description": "Los modelos preentrenados son modelos de Aprendizaje Automático (ML) que han sido entrenados previamente en un gran conjunto de datos para resolver una tarea o conjunto de tareas específicas. Estos modelos aprenden patrones, características y representaciones de los datos de entrenamiento, que luego pueden ajustarse o adaptarse para otras tareas relacionadas. El preentrenamiento proporciona un buen punto de partida, reduciendo la cantidad de datos y cómputo necesarios para entrenar un nuevo modelo desde cero.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "Pre-trained Models: Past, Present and Future",
+        "title": "Modelos Preentrenados: Pasado, Presente y Futuro",
         "url": "https://www.sciencedirect.com/science/article/pii/S2666651021000231",
         "type": "article"
       }
     ]
   },
   "1Ga6DbOPc6Crz7ilsZMYy": {
-    "title": "Benefits of Pre-trained Models",
-    "description": "Pre-trained models offer several benefits in AI engineering by significantly reducing development time and computational resources because these models are trained on large datasets and can be fine-tuned for specific tasks, which enables quicker deployment and better performance with less data. They help overcome the challenge of needing vast amounts of labeled data and computational power for training from scratch. Additionally, pre-trained models often demonstrate improved accuracy, generalization, and robustness across different tasks, making them ideal for applications in natural language processing, computer vision, and other AI domains.\n\nLearn more from the following resources:",
+    "title": "Beneficios de los Modelos Preentrenados",
+    "description": "Los modelos preentrenados ofrecen varios beneficios en la ingeniería de IA al reducir significativamente el tiempo de desarrollo y los recursos computacionales, ya que estos modelos se entrenan en grandes conjuntos de datos y pueden ajustarse para tareas específicas, lo que permite una implementación más rápida y un mejor rendimiento con menos datos. Ayudan a superar el desafío de necesitar grandes cantidades de datos etiquetados y potencia computacional para entrenar desde cero. Además, los modelos preentrenados a menudo demuestran una precisión, generalización y robustez mejoradas en diferentes tareas, lo que los hace ideales para aplicaciones en procesamiento del lenguaje natural, visión por computadora y otros dominios de la IA.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
-        "title": "Why Pre-Trained Models Matter For Machine Learning",
+        "title": "Por Qué los Modelos Preentrenados son Importantes para el Aprendizaje Automático",
         "url": "https://www.ahead.com/resources/why-pre-trained-models-matter-for-machine-learning/",
         "type": "article"
       },
       {
-        "title": "Why You Should Use Pre-Trained Models Versus Building Your Own",
+        "title": "Por Qué Deberías Usar Modelos Preentrenados en Lugar de Construir los Tuyos Propios",
         "url": "https://cohere.com/blog/pre-trained-vs-in-house-nlp-models",
         "type": "article"
       }
     ]
   },
   "MXqbQGhNM3xpXlMC2ib_6": {
-    "title": "Limitations and Considerations",
-    "description": "Pre-trained models, while powerful, come with several limitations and considerations. They may carry biases present in the training data, leading to unintended or discriminatory outcomes, these models are also typically trained on general data, so they might not perform well on niche or domain-specific tasks without further fine-tuning. Another concern is the \"black-box\" nature of many pre-trained models, which can make their decision-making processes hard to interpret and explain.\n\nLearn more from the following resources:",
+    "title": "Limitaciones y Consideraciones",
+    "description": "Los modelos preentrenados, aunque potentes, vienen con varias limitaciones y consideraciones. Pueden contener sesgos presentes en los datos de entrenamiento, lo que lleva a resultados no deseados o discriminatorios; estos modelos también suelen entrenarse con datos generales, por lo que es posible que no funcionen bien en tareas de nicho o específicas del dominio sin un ajuste fino adicional. Otra preocupación es la naturaleza de \"caja negra\" de muchos modelos preentrenados, lo que puede dificultar la interpretación y explicación de sus procesos de toma de decisiones.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
-        "title": "Pre-trained Topic Models: Advantages and Limitation",
+        "title": "Modelos de Tópicos Preentrenados: Ventajas y Limitaciones",
         "url": "https://www.kaggle.com/code/amalsalilan/pretrained-topic-models-advantages-and-limitation",
         "type": "article"
       },
       {
-        "title": "Should You Use Open Source Large Language Models?",
+        "title": "¿Deberías Usar Modelos de Lenguaje Grandes de Código Abierto?",
         "url": "https://www.youtube.com/watch?v=y9k-U9AuDeM",
         "type": "video"
       }
     ]
   },
   "2WbVpRLqwi3Oeqk1JPui4": {
-    "title": "Open AI Models",
-    "description": "OpenAI provides a variety of models designed for diverse tasks. GPT models like GPT-3 and GPT-4 handle text generation, conversation, and translation, offering context-aware responses, while Codex specializes in generating and debugging code across multiple languages. DALL-E creates images from text descriptions, supporting applications in design and content creation, and Whisper is a speech recognition model that converts spoken language to text for transcription and voice-to-text tasks.\n\nLearn more from the following resources:",
+    "title": "Modelos de OpenAI",
+    "description": "OpenAI proporciona una variedad de modelos diseñados para diversas tareas. Los modelos GPT como GPT-3 y GPT-4 manejan la generación de texto, la conversación y la traducción, ofreciendo respuestas conscientes del contexto, mientras que Codex se especializa en generar y depurar código en múltiples lenguajes. DALL-E crea imágenes a partir de descripciones de texto, apoyando aplicaciones en diseño y creación de contenido, y Whisper es un modelo de reconocimiento de voz que convierte el lenguaje hablado en texto para tareas de transcripción y voz a texto.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
-        "title": "OpenAI Models Overview",
+        "title": "Descripción General de los Modelos de OpenAI",
         "url": "https://platform.openai.com/docs/models",
         "type": "article"
       },
       {
-        "title": "OpenAI’s new “deep-thinking” o1 model crushes coding benchmarks",
+        "title": "El nuevo modelo o1 de “pensamiento profundo” de OpenAI supera los puntos de referencia de codificación",
         "url": "https://www.youtube.com/watch?v=6xlPJiNpCVw",
         "type": "video"
       }
     ]
   },
   "vvpYkmycH0_W030E-L12f": {
-    "title": "Capabilities / Context Length",
-    "description": "A key aspect of the OpenAI models is their context length, which refers to the amount of input text the model can process at once. Earlier models like GPT-3 had a context length of up to 4,096 tokens (words or word pieces), while more recent models like GPT-4 can handle significantly larger context lengths, some supporting up to 32,768 tokens. This extended context length enables the models to handle more complex tasks, such as maintaining long conversations or processing lengthy documents, which enhances their utility in real-world applications like legal document analysis or code generation.\n\nLearn more from the following resources:",
+    "title": "Capacidades / Longitud del Contexto",
+    "description": "Un aspecto clave de los modelos de OpenAI es la longitud de su contexto, que se refiere a la cantidad de texto de entrada que el modelo puede procesar a la vez. Los modelos anteriores como GPT-3 tenían una longitud de contexto de hasta 4,096 tokens (palabras o fragmentos de palabras), mientras que los modelos más recientes como GPT-4 pueden manejar longitudes de contexto significativamente mayores, algunos soportando hasta 32,768 tokens. Esta longitud de contexto extendida permite a los modelos manejar tareas más complejas, como mantener conversaciones largas o procesar documentos extensos, lo que mejora su utilidad en aplicaciones del mundo real como el análisis de documentos legales o la generación de código.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
-        "title": "Managing Context",
+        "title": "Gestión del Contexto",
         "url": "https://platform.openai.com/docs/guides/conversation-state?api-mode=responses#managing-context-for-text-generation",
         "type": "article"
       },
       {
-        "title": "Capabilities",
+        "title": "Capacidades",
         "url": "https://platform.openai.com/docs/guides/text-generation",
         "type": "article"
       }
     ]
   },
   "LbB2PeytxRSuU07Bk0KlJ": {
-    "title": "Cut-off Dates / Knowledge",
-    "description": "OpenAI models, such as GPT-3.5 and GPT-4, have a knowledge cutoff date, which refers to the last point in time when the model was trained on data. For instance, as of the current version of GPT-4, the knowledge cutoff is October 2023. This means the model does not have awareness or knowledge of events, advancements, or data that occurred after that date. Consequently, the model may lack information on more recent developments, research, or real-time events unless explicitly updated in future versions. This limitation is important to consider when using the models for time-sensitive tasks or inquiries involving recent knowledge.\n\nLearn more from the following resources:",
+    "title": "Fechas de Corte / Conocimiento",
+    "description": "Los modelos de OpenAI, como GPT-3.5 y GPT-4, tienen una fecha de corte de conocimiento, que se refiere al último momento en el que el modelo fue entrenado con datos. Por ejemplo, a partir de la versión actual de GPT-4, el corte de conocimiento es octubre de 2023. Esto significa que el modelo no tiene conciencia ni conocimiento de eventos, avances o datos ocurridos después de esa fecha. En consecuencia, el modelo puede carecer de información sobre desarrollos más recientes, investigaciones o eventos en tiempo real, a menos que se actualice explícitamente en versiones futuras. Es importante considerar esta limitación al usar los modelos para tareas sensibles al tiempo o consultas que involucren conocimiento reciente.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
-        "title": "Knowledge Cutoff Dates of all LLMs explained",
+        "title": "Explicación de las Fechas de Corte de Conocimiento de todos los LLMs",
         "url": "https://otterly.ai/blog/knowledge-cutoff/",
         "type": "article"
       },
       {
-        "title": "Knowledge Cutoff Dates For ChatGPT, Meta Ai, Copilot, Gemini, Claude",
+        "title": "Fechas de Corte de Conocimiento Para ChatGPT, Meta Ai, Copilot, Gemini, Claude",
         "url": "https://computercity.com/artificial-intelligence/knowledge-cutoff-dates-llms",
         "type": "article"
       }
     ]
   },
   "hy6EyKiNxk1x84J63dhez": {
-    "title": "Anthropic's Claude",
-    "description": "Anthropic's Claude is an AI language model designed to facilitate safe and scalable AI systems. Named after Claude Shannon, the father of information theory, Claude focuses on responsible AI use, emphasizing safety, alignment with human intentions, and minimizing harmful outputs. Built as a competitor to models like OpenAI's GPT, Claude is designed to handle natural language tasks such as generating text, answering questions, and supporting conversations, with a strong focus on aligning AI behavior with user goals while maintaining transparency and avoiding harmful biases.\n\nLearn more from the following resources:",
+    "title": "Claude de Anthropic",
+    "description": "Claude de Anthropic es un modelo de lenguaje de IA diseñado para facilitar sistemas de IA seguros y escalables. Nombrado en honor a Claude Shannon, el padre de la teoría de la información, Claude se enfoca en el uso responsable de la IA, enfatizando la seguridad, la alineación con las intenciones humanas y la minimización de resultados dañinos. Construido como un competidor de modelos como GPT de OpenAI, Claude está diseñado para manejar tareas de lenguaje natural como generar texto, responder preguntas y apoyar conversaciones, con un fuerte enfoque en alinear el comportamiento de la IA con los objetivos del usuario mientras se mantiene la transparencia y se evitan sesgos dañinos.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
         "title": "Claude",
@@ -364,15 +364,15 @@
         "type": "article"
       },
       {
-        "title": "How To Use Claude Pro For Beginners",
+        "title": "Cómo Usar Claude Pro para Principiantes",
         "url": "https://www.youtube.com/watch?v=J3X_JWQkvo8",
         "type": "video"
       }
     ]
   },
   "oe8E6ZIQWuYvHVbYJHUc1": {
-    "title": "Google's Gemini",
-    "description": "Google Gemini is an advanced AI model by Google DeepMind, designed to integrate natural language processing with multimodal capabilities, enabling it to understand and generate not just text but also images, videos, and other data types. It combines generative AI with reasoning skills, making it effective for complex tasks requiring logical analysis and contextual understanding. Built on Google's extensive knowledge base and infrastructure, Gemini aims to offer high accuracy, efficiency, and safety, positioning it as a competitor to models like OpenAI's GPT-4.\n\nLearn more from the following resources:",
+    "title": "Gemini de Google",
+    "description": "Google Gemini es un modelo de IA avanzado de Google DeepMind, diseñado para integrar el procesamiento del lenguaje natural con capacidades multimodales, lo que le permite comprender y generar no solo texto, sino también imágenes, videos y otros tipos de datos. Combina la IA generativa con habilidades de razonamiento, lo que lo hace efectivo para tareas complejas que requieren análisis lógico y comprensión contextual. Construido sobre la extensa base de conocimientos e infraestructura de Google, Gemini tiene como objetivo ofrecer alta precisión, eficiencia y seguridad, posicionándolo como un competidor de modelos como GPT-4 de OpenAI.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
         "title": "Google Gemini",
@@ -380,28 +380,28 @@
         "type": "article"
       },
       {
-        "title": "Google's Gemini Documentation",
+        "title": "Documentación de Gemini de Google",
         "url": "https://workspace.google.com/solutions/ai/",
         "type": "article"
       },
       {
-        "title": "Welcome to the Gemini era",
+        "title": "Bienvenido a la era Gemini",
         "url": "https://www.youtube.com/watch?v=_fuimO6ErKI",
         "type": "video"
       }
     ]
   },
   "3PQVZbcr4neNMRr6CuNzS": {
-    "title": "Azure AI",
-    "description": "Azure AI is a suite of AI services and tools provided by Microsoft through its Azure cloud platform. It includes pre-built AI models for natural language processing, computer vision, and speech, as well as tools for developing custom machine learning models using services like Azure Machine Learning. Azure AI enables developers to integrate AI capabilities into applications with APIs for tasks like sentiment analysis, image recognition, and language translation. It also supports responsible AI development with features for model monitoring, explainability, and fairness, aiming to make AI accessible, scalable, and secure across industries.\n\nLearn more from the following resources:",
+    "title": "IA de Azure",
+    "description": "Azure AI es un conjunto de servicios y herramientas de IA proporcionados por Microsoft a través de su plataforma en la nube Azure. Incluye modelos de IA preconstruidos para procesamiento del lenguaje natural, visión por computadora y voz, así como herramientas para desarrollar modelos de aprendizaje automático personalizados utilizando servicios como Azure Machine Learning. Azure AI permite a los desarrolladores integrar capacidades de IA en aplicaciones con API para tareas como análisis de sentimientos, reconocimiento de imágenes y traducción de idiomas. También apoya el desarrollo responsable de IA con funciones para el monitoreo de modelos, la explicabilidad y la equidad, con el objetivo de hacer que la IA sea accesible, escalable y segura en todas las industrias.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
-        "title": "Azure AI",
+        "title": "IA de Azure",
         "url": "https://azure.microsoft.com/en-gb/solutions/ai",
         "type": "article"
       },
       {
-        "title": "How to Choose the Right Models for Your Apps",
+        "title": "Cómo Elegir los Modelos Adecuados para tus Aplicaciones",
         "url": "https://www.youtube.com/watch?v=sx_uGylH8eg",
         "type": "video"
       }
@@ -409,7 +409,7 @@
   },
   "OkYO-aSPiuVYuLXHswBCn": {
     "title": "AWS Sagemaker",
-    "description": "AWS SageMaker is a fully managed machine learning service from Amazon Web Services that enables developers and data scientists to build, train, and deploy machine learning models at scale. It provides an integrated development environment, simplifying the entire ML workflow, from data preparation and model development to training, tuning, and inference. SageMaker supports popular ML frameworks like TensorFlow, PyTorch, and Scikit-learn, and offers features like automated model tuning, model monitoring, and one-click deployment. It's designed to make machine learning more accessible and scalable, even for large enterprise applications.\n\nLearn more from the following resources:",
+    "description": "AWS SageMaker es un servicio de aprendizaje automático totalmente gestionado de Amazon Web Services que permite a los desarrolladores y científicos de datos construir, entrenar e implementar modelos de aprendizaje automático a escala. Proporciona un entorno de desarrollo integrado, simplificando todo el flujo de trabajo de ML, desde la preparación de datos y el desarrollo de modelos hasta el entrenamiento, el ajuste y la inferencia. SageMaker admite marcos de ML populares como TensorFlow, PyTorch y Scikit-learn, y ofrece funciones como el ajuste automatizado de modelos, el monitoreo de modelos y la implementación con un solo clic. Está diseñado para hacer que el aprendizaje automático sea más accesible y escalable, incluso para grandes aplicaciones empresariales.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
         "title": "AWS SageMaker",
@@ -417,34 +417,34 @@
         "type": "article"
       },
       {
-        "title": "Introduction to Amazon SageMaker",
+        "title": "Introducción a Amazon SageMaker",
         "url": "https://www.youtube.com/watch?v=Qv_Tr_BCFCQ",
         "type": "video"
       }
     ]
   },
   "8XjkRqHOdyH-DbXHYiBEt": {
-    "title": "Hugging Face Models",
-    "description": "Hugging Face models are a collection of pre-trained machine learning models available through the Hugging Face platform, covering a wide range of tasks like natural language processing, computer vision, and audio processing. The platform includes models for tasks such as text classification, translation, summarization, question answering, and more, with popular models like BERT, GPT, T5, and CLIP. Hugging Face provides easy-to-use tools and APIs that allow developers to access, fine-tune, and deploy these models, fostering a collaborative community where users can share, modify, and contribute models to improve AI research and application development.\n\nLearn more from the following resources:",
+    "title": "Modelos de Hugging Face",
+    "description": "Los modelos de Hugging Face son una colección de modelos de aprendizaje automático preentrenados disponibles a través de la plataforma Hugging Face, que cubren una amplia gama de tareas como el procesamiento del lenguaje natural, la visión por computadora y el procesamiento de audio. La plataforma incluye modelos para tareas como clasificación de texto, traducción, resumen, respuesta a preguntas y más, con modelos populares como BERT, GPT, T5 y CLIP. Hugging Face proporciona herramientas y API fáciles de usar que permiten a los desarrolladores acceder, ajustar e implementar estos modelos, fomentando una comunidad colaborativa donde los usuarios pueden compartir, modificar y contribuir con modelos para mejorar la investigación de IA y el desarrollo de aplicaciones.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
-        "title": "Hugging Face Models",
+        "title": "Modelos de Hugging Face",
         "url": "https://huggingface.co/models",
         "type": "article"
       }
     ]
   },
   "n-Ud2dXkqIzK37jlKItN4": {
-    "title": "Mistral AI",
-    "description": "Mistral AI is a company focused on developing open-weight, large language models (LLMs) to provide high-performance AI solutions. Mistral aims to create models that are both efficient and versatile, making them suitable for a wide range of natural language processing tasks, including text generation, translation, and summarization. By releasing open-weight models, Mistral promotes transparency and accessibility, allowing developers to customize and deploy AI solutions more flexibly compared to proprietary models.\n\nLearn more from the resources:",
+    "title": "IA Mistral",
+    "description": "Mistral AI es una empresa enfocada en el desarrollo de modelos de lenguaje grandes (LLM) de peso abierto para proporcionar soluciones de IA de alto rendimiento. Mistral tiene como objetivo crear modelos que sean eficientes y versátiles, haciéndolos adecuados para una amplia gama de tareas de procesamiento del lenguaje natural, incluida la generación de texto, la traducción y el resumen. Al lanzar modelos de peso abierto, Mistral promueve la transparencia y la accesibilidad, lo que permite a los desarrolladores personalizar e implementar soluciones de IA de manera más flexible en comparación con los modelos propietarios.\n\nAprende más de los recursos:",
     "links": [
       {
-        "title": "Mistral AI",
+        "title": "IA Mistral",
         "url": "https://mistral.ai/",
         "type": "article"
       },
       {
-        "title": "Mistral AI: The Gen AI Start-up you did not know existed",
+        "title": "Mistral AI: La Start-up de IA Generativa que no sabías que existía",
         "url": "https://www.youtube.com/watch?v=vzrRGd18tAg",
         "type": "video"
       }
@@ -452,7 +452,7 @@
   },
   "a7qsvoauFe5u953I699ps": {
     "title": "Cohere",
-    "description": "Cohere is an AI platform that specializes in natural language processing (NLP) by providing large language models designed to help developers build and deploy text-based applications. Cohere’s models are used for tasks such as text classification, language generation, semantic search, and sentiment analysis. Unlike some other providers, Cohere emphasizes simplicity and scalability, offering an easy-to-use API that allows developers to fine-tune models on custom data for specific use cases. Additionally, Cohere provides robust multilingual support and focuses on ensuring that its NLP solutions are both accessible and enterprise-ready, catering to a wide range of industries.\n\nLearn more from the following resources:",
+    "description": "Cohere es una plataforma de IA que se especializa en el procesamiento del lenguaje natural (NLP) al proporcionar modelos de lenguaje grandes diseñados para ayudar a los desarrolladores a construir e implementar aplicaciones basadas en texto. Los modelos de Cohere se utilizan para tareas como la clasificación de texto, la generación de lenguaje, la búsqueda semántica y el análisis de sentimientos. A diferencia de otros proveedores, Cohere enfatiza la simplicidad y la escalabilidad, ofreciendo una API fácil de usar que permite a los desarrolladores ajustar modelos con datos personalizados para casos de uso específicos. Además, Cohere proporciona un sólido soporte multilingüe y se enfoca en garantizar que sus soluciones de NLP sean accesibles y estén listas para la empresa, atendiendo a una amplia gama de industrias.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
         "title": "Cohere",
@@ -460,344 +460,344 @@
         "type": "article"
       },
       {
-        "title": "What Does Cohere Do?",
+        "title": "¿Qué Hace Cohere?",
         "url": "https://medium.com/geekculture/what-does-cohere-do-cdadf6d70435",
         "type": "article"
       }
     ]
   },
   "5ShWZl1QUqPwO-NRGN85V": {
-    "title": "OpenAI Models",
-    "description": "OpenAI provides a variety of models designed for diverse tasks. GPT models like GPT-3 and GPT-4 handle text generation, conversation, and translation, offering context-aware responses, while Codex specializes in generating and debugging code across multiple languages. DALL-E creates images from text descriptions, supporting applications in design and content creation, and Whisper is a speech recognition model that converts spoken language to text for transcription and voice-to-text tasks.\n\nLearn more from the following resources:",
+    "title": "Modelos de OpenAI",
+    "description": "OpenAI proporciona una variedad de modelos diseñados para diversas tareas. Los modelos GPT como GPT-3 y GPT-4 manejan la generación de texto, la conversación y la traducción, ofreciendo respuestas conscientes del contexto, mientras que Codex se especializa en generar y depurar código en múltiples lenguajes. DALL-E crea imágenes a partir de descripciones de texto, apoyando aplicaciones en diseño y creación de contenido, y Whisper es un modelo de reconocimiento de voz que convierte el lenguaje hablado en texto para tareas de transcripción y voz a texto.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
-        "title": "OpenAI Models Overview",
+        "title": "Descripción General de los Modelos de OpenAI",
         "url": "https://platform.openai.com/docs/models",
         "type": "article"
       }
     ]
   },
   "zdeuA4GbdBl2DwKgiOA4G": {
-    "title": "OpenAI API",
-    "description": "The OpenAI API provides access to powerful AI models like GPT, Codex, DALL-E, and Whisper, enabling developers to integrate capabilities such as text generation, code assistance, image creation, and speech recognition into their applications via a simple, scalable interface.\n\nLearn more from the following resources:",
+    "title": "API de OpenAI",
+    "description": "La API de OpenAI proporciona acceso a potentes modelos de IA como GPT, Codex, DALL-E y Whisper, lo que permite a los desarrolladores integrar capacidades como generación de texto, asistencia de código, creación de imágenes y reconocimiento de voz en sus aplicaciones a través de una interfaz simple y escalable.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
-        "title": "OpenAI API",
+        "title": "API de OpenAI",
         "url": "https://openai.com/api/",
         "type": "article"
       }
     ]
   },
   "_bPTciEA1GT1JwfXim19z": {
-    "title": "Chat Completions API",
-    "description": "The OpenAI Chat Completions API is a powerful interface that allows developers to integrate conversational AI into applications by utilizing models like GPT-3.5 and GPT-4. It is designed to manage multi-turn conversations, keeping context across interactions, making it ideal for chatbots, virtual assistants, and interactive AI systems. With the API, users can structure conversations by providing messages in a specific format, where each message has a role (e.g., \"system\" to guide the model, \"user\" for input, and \"assistant\" for responses).\n\nLearn more from the following resources:",
+    "title": "API de Finalización de Chat",
+    "description": "La API de Finalización de Chat de OpenAI es una interfaz potente que permite a los desarrolladores integrar IA conversacional en aplicaciones utilizando modelos como GPT-3.5 y GPT-4. Está diseñada para gestionar conversaciones de varios turnos, manteniendo el contexto a través de las interacciones, lo que la hace ideal para chatbots, asistentes virtuales y sistemas de IA interactivos. Con la API, los usuarios pueden estructurar conversaciones proporcionando mensajes en un formato específico, donde cada mensaje tiene un rol (por ejemplo, \"sistema\" para guiar el modelo, \"usuario\" para la entrada y \"asistente\" para las respuestas).\n\nAprende más de los siguientes recursos:",
     "links": [
       {
-        "title": "Create Chat Completions",
+        "title": "Crear Finalizaciones de Chat",
         "url": "https://platform.openai.com/docs/api-reference/chat/create",
         "type": "article"
       },
       {
-        "title": "Getting Start with Chat Completions API",
+        "title": "Primeros Pasos con la API de Finalización de Chat",
         "url": "https://medium.com/the-ai-archives/getting-started-with-openais-chat-completions-api-in-2024-462aae00bf0a",
         "type": "article"
       }
     ]
   },
   "9-5DYeOnKJq9XvEMWP45A": {
-    "title": "Writing Prompts",
-    "description": "Prompts for the OpenAI API are carefully crafted inputs designed to guide the language model in generating specific, high-quality content. These prompts can be used to direct the model to create stories, articles, dialogue, or even detailed responses on particular topics. Effective prompts set clear expectations by providing context, specifying the format, or including examples, such as \"Write a short sci-fi story about a future where humans can communicate with animals,\" or \"Generate a detailed summary of the key benefits of using renewable energy.\" Well-designed prompts help ensure that the API produces coherent, relevant, and creative outputs, making it easier to achieve desired results across various applications.\n\nLearn more from the following resources:",
+    "title": "Escribiendo Prompts",
+    "description": "Los prompts para la API de OpenAI son entradas cuidadosamente elaboradas diseñadas para guiar al modelo de lenguaje en la generación de contenido específico y de alta calidad. Estos prompts se pueden usar para dirigir el modelo a crear historias, artículos, diálogos o incluso respuestas detalladas sobre temas particulares. Los prompts efectivos establecen expectativas claras al proporcionar contexto, especificar el formato o incluir ejemplos, como \"Escribe una breve historia de ciencia ficción sobre un futuro donde los humanos pueden comunicarse con los animales\" o \"Genera un resumen detallado de los beneficios clave del uso de energía renovable\". Los prompts bien diseñados ayudan a garantizar que la API produzca resultados coherentes, relevantes y creativos, lo que facilita el logro de los resultados deseados en diversas aplicaciones.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
-        "title": "Visit Dedicated Prompt Engineering Roadmap",
+        "title": "Visita el Roadmap Dedicado de Ingeniería de Prompts",
         "url": "https://roadmap.sh/prompt-engineering",
         "type": "article"
       },
       {
-        "title": "How to Write AI prompts",
+        "title": "Cómo Escribir Prompts de IA",
         "url": "https://www.descript.com/blog/article/how-to-write-ai-prompts",
         "type": "article"
       },
       {
-        "title": "Prompt Engineering Guide",
+        "title": "Guía de Ingeniería de Prompts",
         "url": "https://www.promptingguide.ai/",
         "type": "article"
       }
     ]
   },
   "nyBgEHvUhwF-NANMwkRJW": {
-    "title": "Open AI Playground",
-    "description": "The OpenAI Playground is an interactive web interface that allows users to experiment with OpenAI's language models, such as GPT-3 and GPT-4, without needing to write code. It provides a user-friendly environment where you can input prompts, adjust parameters like temperature and token limits, and see how the models generate responses in real-time. The Playground helps users test different use cases, from text generation to question answering, and refine prompts for better outputs. It's a valuable tool for exploring the capabilities of OpenAI models, prototyping ideas, and understanding how the models behave before integrating them into applications.\n\nLearn more from the following resources:",
+    "title": "Playground de OpenAI",
+    "description": "El Playground de OpenAI es una interfaz web interactiva que permite a los usuarios experimentar con los modelos de lenguaje de OpenAI, como GPT-3 y GPT-4, sin necesidad de escribir código. Proporciona un entorno fácil de usar donde puedes ingresar prompts, ajustar parámetros como la temperatura y los límites de tokens, y ver cómo los modelos generan respuestas en tiempo real. El Playground ayuda a los usuarios a probar diferentes casos de uso, desde la generación de texto hasta la respuesta a preguntas, y a refinar los prompts para obtener mejores resultados. Es una herramienta valiosa para explorar las capacidades de los modelos de OpenAI, crear prototipos de ideas y comprender cómo se comportan los modelos antes de integrarlos en las aplicaciones.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
-        "title": "OpenAI Playground",
+        "title": "Playground de OpenAI",
         "url": "https://platform.openai.com/playground/chat",
         "type": "article"
       },
       {
-        "title": "How to Use OpenAi Playground Like a Pro",
+        "title": "Cómo Usar el Playground de OpenAI Como un Profesional",
         "url": "https://www.youtube.com/watch?v=PLxpvtODiqs",
         "type": "video"
       }
     ]
   },
   "15XOFdVp0IC-kLYPXUJWh": {
-    "title": "Fine-tuning",
-    "description": "Fine-tuning the OpenAI API involves adapting pre-trained models, such as GPT, to specific use cases by training them on custom datasets. This process allows you to refine the model's behavior and improve its performance on specialized tasks, like generating domain-specific text or following particular patterns. By providing labeled examples of the desired input-output pairs, you guide the model to better understand and predict the appropriate responses for your use case.\n\nLearn more from the following resources:",
+    "title": "Ajuste Fino",
+    "description": "El ajuste fino de la API de OpenAI implica adaptar modelos preentrenados, como GPT, a casos de uso específicos entrenándolos en conjuntos de datos personalizados. Este proceso te permite refinar el comportamiento del modelo y mejorar su rendimiento en tareas especializadas, como generar texto específico del dominio o seguir patrones particulares. Al proporcionar ejemplos etiquetados de los pares de entrada-salida deseados, guías al modelo para que comprenda y prediga mejor las respuestas apropiadas para tu caso de uso.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
-        "title": "Fine-tuning Documentation",
+        "title": "Documentación de Ajuste Fino",
         "url": "https://platform.openai.com/docs/guides/fine-tuning",
         "type": "article"
       },
       {
-        "title": "Fine-tuning ChatGPT with OpenAI Tutorial",
+        "title": "Tutorial de Ajuste Fino de ChatGPT con OpenAI",
         "url": "https://www.youtube.com/watch?v=VVKcSf6r3CM",
         "type": "video"
       }
     ]
   },
   "qzvp6YxWDiGakA2mtspfh": {
-    "title": "Maximum Tokens",
-    "description": "The OpenAI API has different maximum token limits depending on the model being used. For instance, GPT-3 has a limit of 4,096 tokens, while GPT-4 can support larger inputs, with some versions allowing up to 8,192 tokens, and extended versions reaching up to 32,768 tokens. Tokens include both the input text and the generated output, so longer inputs mean less space for responses. Managing token limits is crucial to ensure the model can handle the entire input and still generate a complete response, especially for tasks involving lengthy documents or multi-turn conversations.\n\nLearn more from the following resources:",
+    "title": "Máximo de Tokens",
+    "description": "La API de OpenAI tiene diferentes límites máximos de tokens según el modelo que se utilice. Por ejemplo, GPT-3 tiene un límite de 4,096 tokens, mientras que GPT-4 puede admitir entradas más grandes, con algunas versiones que permiten hasta 8,192 tokens y versiones extendidas que alcanzan hasta 32,768 tokens. Los tokens incluyen tanto el texto de entrada como la salida generada, por lo que las entradas más largas significan menos espacio para las respuestas. Gestionar los límites de tokens es crucial para garantizar que el modelo pueda manejar toda la entrada y aun así generar una respuesta completa, especialmente para tareas que involucran documentos extensos o conversaciones de varios turnos.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
-        "title": "Maximum Tokens",
+        "title": "Máximo de Tokens",
         "url": "https://platform.openai.com/docs/guides/rate-limits",
         "type": "article"
       },
       {
-        "title": "The Ins and Outs of GPT Token Limits",
+        "title": "Los Entresijos de los Límites de Tokens de GPT",
         "url": "https://www.supernormal.com/blog/gpt-token-limits",
         "type": "article"
       }
     ]
   },
   "FjV3oD7G2Ocq5HhUC17iH": {
-    "title": "Token Counting",
-    "description": "Token counting refers to tracking the number of tokens processed during interactions with language models, including both input and output text. Tokens are units of text that can be as short as a single character or as long as a word, and models like GPT process text by splitting it into these tokens. Knowing how many tokens are used is crucial because the API has token limits (e.g., 4,096 for GPT-3 and up to 32,768 for some versions of GPT-4), and costs are typically calculated based on the total number of tokens processed.\n\nLearn more from the following resources:",
+    "title": "Conteo de Tokens",
+    "description": "El conteo de tokens se refiere al seguimiento del número de tokens procesados durante las interacciones con los modelos de lenguaje, incluyendo tanto el texto de entrada como el de salida. Los tokens son unidades de texto que pueden ser tan cortas como un solo carácter o tan largas como una palabra, y los modelos como GPT procesan el texto dividiéndolo en estos tokens. Saber cuántos tokens se utilizan es crucial porque la API tiene límites de tokens (por ejemplo, 4,096 para GPT-3 y hasta 32,768 para algunas versiones de GPT-4), y los costos generalmente se calculan en función del número total de tokens procesados.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
-        "title": "OpenAI Tokenizer Tool",
+        "title": "Herramienta Tokenizer de OpenAI",
         "url": "https://platform.openai.com/tokenizer",
         "type": "article"
       },
       {
-        "title": "How to count tokens with Tiktoken",
+        "title": "Cómo contar tokens con Tiktoken",
         "url": "https://cookbook.openai.com/examples/how_to_count_tokens_with_tiktoken",
         "type": "article"
       }
     ]
   },
   "DZPM9zjCbYYWBPLmQImxQ": {
-    "title": "Pricing Considerations",
-    "description": "When using the OpenAI API, pricing considerations depend on factors like the model type, usage volume, and specific features utilized. Different models, such as GPT-3.5, GPT-4, or DALL-E, have varying cost structures based on the complexity of the model and the number of tokens processed (inputs and outputs). For cost efficiency, you should optimize prompt design, monitor usage, and consider rate limits or volume discounts offered by OpenAI for high usage.",
+    "title": "Consideraciones de Precios",
+    "description": "Al usar la API de OpenAI, las consideraciones de precios dependen de factores como el tipo de modelo, el volumen de uso y las características específicas utilizadas. Diferentes modelos, como GPT-3.5, GPT-4 o DALL-E, tienen diferentes estructuras de costos basadas en la complejidad del modelo y el número de tokens procesados (entradas y salidas). Para la eficiencia de costos, debes optimizar el diseño de los prompts, monitorear el uso y considerar los límites de velocidad o los descuentos por volumen ofrecidos por OpenAI para un uso elevado.",
     "links": [
       {
-        "title": "OpenAI API Pricing",
+        "title": "Precios de la API de OpenAI",
         "url": "https://openai.com/api/pricing/",
         "type": "article"
       }
     ]
   },
   "8ndKHDJgL_gYwaXC7XMer": {
-    "title": "AI Safety and Ethics",
-    "description": "AI safety and ethics involve establishing guidelines and best practices to ensure that artificial intelligence systems are developed, deployed, and used in a manner that prioritizes human well-being, fairness, and transparency. This includes addressing risks such as bias, privacy violations, unintended consequences, and ensuring that AI operates reliably and predictably, even in complex environments. Ethical considerations focus on promoting accountability, avoiding discrimination, and aligning AI systems with human values and societal norms. Frameworks like explainability, human-in-the-loop design, and robust monitoring are often used to build systems that not only achieve technical objectives but also uphold ethical standards and mitigate potential harms.\n\nLearn more from the following resources:",
+    "title": "Seguridad y Ética de la IA",
+    "description": "La seguridad y la ética de la IA implican establecer directrices y mejores prácticas para garantizar que los sistemas de inteligencia artificial se desarrollen, implementen y utilicen de una manera que priorice el bienestar humano, la equidad y la transparencia. Esto incluye abordar riesgos como el sesgo, las violaciones de la privacidad, las consecuencias no deseadas y garantizar que la IA funcione de manera confiable y predecible, incluso en entornos complejos. Las consideraciones éticas se centran en promover la rendición de cuentas, evitar la discriminación y alinear los sistemas de IA con los valores humanos y las normas sociales. A menudo se utilizan marcos como la explicabilidad, el diseño con intervención humana y el monitoreo robusto para construir sistemas que no solo logren objetivos técnicos, sino que también defiendan los estándares éticos y mitiguen los daños potenciales.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
-        "title": "Understanding Artificial Intelligence Ethics and Safety",
+        "title": "Comprendiendo la Ética y la Seguridad de la Inteligencia Artificial",
         "url": "https://www.turing.ac.uk/news/publications/understanding-artificial-intelligence-ethics-and-safety",
         "type": "article"
       },
       {
-        "title": "What is AI Ethics?",
+        "title": "¿Qué es la Ética de la IA?",
         "url": "https://www.youtube.com/watch?v=aGwYtUzMQUk",
         "type": "video"
       }
     ]
   },
   "cUyLT6ctYQ1pgmodCKREq": {
-    "title": "Prompt Injection Attacks",
-    "description": "Prompt injection attacks are a type of security vulnerability where malicious inputs are crafted to manipulate or exploit AI models, like language models, to produce unintended or harmful outputs. These attacks involve injecting deceptive or adversarial content into the prompt to bypass filters, extract confidential information, or make the model respond in ways it shouldn't. For instance, a prompt injection could trick a model into revealing sensitive data or generating inappropriate responses by altering its expected behavior.\n\nLearn more from the following resources:",
+    "title": "Ataques de Inyección de Prompts",
+    "description": "Los ataques de inyección de prompts son un tipo de vulnerabilidad de seguridad donde se elaboran entradas maliciosas para manipular o explotar modelos de IA, como los modelos de lenguaje, para producir salidas no deseadas o dañinas. Estos ataques implican inyectar contenido engañoso o adversario en el prompt para eludir filtros, extraer información confidencial o hacer que el modelo responda de maneras que no debería. Por ejemplo, una inyección de prompt podría engañar a un modelo para que revele datos confidenciales o genere respuestas inapropiadas alterando su comportamiento esperado.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
-        "title": "Prompt Injection in LLMs",
+        "title": "Inyección de Prompts en LLMs",
         "url": "https://www.promptingguide.ai/prompts/adversarial-prompting/prompt-injection",
         "type": "article"
       },
       {
-        "title": "What is a Prompt Injection Attack?",
+        "title": "¿Qué es un Ataque de Inyección de Prompts?",
         "url": "https://www.wiz.io/academy/prompt-injection-attack",
         "type": "article"
       }
     ]
   },
   "lhIU0ulpvDAn1Xc3ooYz_": {
-    "title": "Bias and Fairness",
-    "description": "Bias and fairness in AI refer to the challenges of ensuring that machine learning models do not produce discriminatory or skewed outcomes. Bias can arise from imbalanced training data, flawed assumptions, or biased algorithms, leading to unfair treatment of certain groups based on race, gender, or other factors. Fairness aims to address these issues by developing techniques to detect, mitigate, and prevent biases in AI systems. Ensuring fairness involves improving data diversity, applying fairness constraints during model training, and continuously monitoring models in production to avoid unintended consequences, promoting ethical and equitable AI use.\n\nLearn more from the following resources:",
+    "title": "Sesgo y Equidad",
+    "description": "El sesgo y la equidad en la IA se refieren a los desafíos de garantizar que los modelos de aprendizaje automático no produzcan resultados discriminatorios o sesgados. El sesgo puede surgir de datos de entrenamiento desequilibrados, suposiciones erróneas o algoritmos sesgados, lo que lleva a un tratamiento injusto de ciertos grupos por motivos de raza, género u otros factores. La equidad tiene como objetivo abordar estos problemas mediante el desarrollo de técnicas para detectar, mitigar y prevenir sesgos en los sistemas de IA. Garantizar la equidad implica mejorar la diversidad de los datos, aplicar restricciones de equidad durante el entrenamiento del modelo y monitorear continuamente los modelos en producción para evitar consecuencias no deseadas, promoviendo un uso ético y equitativo de la IA.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
-        "title": "What Do We Do About the Biases in AI?",
+        "title": "¿Qué Hacemos con los Sesgos en la IA?",
         "url": "https://hbr.org/2019/10/what-do-we-do-about-the-biases-in-ai",
         "type": "article"
       },
       {
-        "title": "AI Bias - What Is It and How to Avoid It?",
+        "title": "Sesgo de IA: ¿Qué es y Cómo Evitarlo?",
         "url": "https://levity.ai/blog/ai-bias-how-to-avoid",
         "type": "article"
       },
       {
-        "title": "What about fairness, bias and discrimination?",
+        "title": "¿Qué pasa con la equidad, el sesgo y la discriminación?",
         "url": "https://ico.org.uk/for-organisations/uk-gdpr-guidance-and-resources/artificial-intelligence/guidance-on-ai-and-data-protection/how-do-we-ensure-fairness-in-ai/what-about-fairness-bias-and-discrimination/",
         "type": "article"
       }
     ]
   },
   "sWBT-j2cRuFqRFYtV_5TK": {
-    "title": "Security and Privacy Concerns",
-    "description": "Security and privacy concerns in AI revolve around the protection of data and the responsible use of models. Key issues include ensuring that sensitive data, such as personal information, is handled securely during collection, processing, and storage, to prevent unauthorized access and breaches. AI models can also inadvertently expose sensitive data if not properly designed, leading to privacy risks through data leakage or misuse. Additionally, there are concerns about model bias, data misuse, and ensuring transparency in how AI decisions are made.\n\nLearn more from the following resources:",
+    "title": "Preocupaciones de Seguridad y Privacidad",
+    "description": "Las preocupaciones de seguridad y privacidad en la IA giran en torno a la protección de los datos y el uso responsable de los modelos. Los problemas clave incluyen garantizar que los datos confidenciales, como la información personal, se manejen de forma segura durante la recopilación, el procesamiento y el almacenamiento, para evitar el acceso no autorizado y las filtraciones. Los modelos de IA también pueden exponer inadvertidamente datos confidenciales si no están diseñados correctamente, lo que genera riesgos de privacidad a través de la fuga o el uso indebido de datos. Además, existen preocupaciones sobre el sesgo del modelo, el uso indebido de los datos y la garantía de transparencia en la forma en que se toman las decisiones de IA.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
-        "title": "Examining Privacy Risks in AI Systems",
+        "title": "Examinando los Riesgos de Privacidad en los Sistemas de IA",
         "url": "https://transcend.io/blog/ai-and-privacy",
         "type": "article"
       },
       {
-        "title": "AI Is Dangerous, but Not for the Reasons You Think | Sasha Luccioni | TED",
+        "title": "La IA es Peligrosa, pero No por las Razones que Crees | Sasha Luccioni | TED",
         "url": "https://www.youtube.com/watch?v=eXdVDhOGqoE",
         "type": "video"
       }
     ]
   },
   "Pt-AJmSJrOxKvolb5_HEv": {
-    "title": "Conducting adversarial testing",
-    "description": "Adversarial testing involves intentionally exposing machine learning models to deceptive, perturbed, or carefully crafted inputs to evaluate their robustness and identify vulnerabilities. The goal is to simulate potential attacks or edge cases where the model might fail, such as subtle manipulations in images, text, or data that cause the model to misclassify or produce incorrect outputs. This type of testing helps to improve model resilience, particularly in sensitive applications like cybersecurity, autonomous systems, and finance.\n\nLearn more from the following resources:",
+    "title": "Realización de pruebas adversarias",
+    "description": "Las pruebas adversarias implican exponer intencionalmente los modelos de aprendizaje automático a entradas engañosas, perturbadas o cuidadosamente elaboradas para evaluar su robustez e identificar vulnerabilidades. El objetivo es simular ataques potenciales o casos límite en los que el modelo podría fallar, como manipulaciones sutiles en imágenes, texto o datos que hacen que el modelo clasifique erróneamente o produzca resultados incorrectos. Este tipo de pruebas ayuda a mejorar la resiliencia del modelo, particularmente en aplicaciones sensibles como la ciberseguridad, los sistemas autónomos y las finanzas.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
-        "title": "Adversarial Testing for Generative AI",
+        "title": "Pruebas Adversarias para IA Generativa",
         "url": "https://developers.google.com/machine-learning/resources/adv-testing",
         "type": "article"
       },
       {
-        "title": "Adversarial Testing: Definition, Examples and Resources",
+        "title": "Pruebas Adversarias: Definición, Ejemplos y Recursos",
         "url": "https://www.leapwork.com/blog/adversarial-testing",
         "type": "article"
       }
     ]
   },
   "ljZLa3yjQpegiZWwtnn_q": {
-    "title": "OpenAI Moderation API",
-    "description": "The OpenAI Moderation API helps detect and filter harmful content by analyzing text for issues like hate speech, violence, self-harm, and adult content. It uses machine learning models to identify inappropriate or unsafe language, allowing developers to create safer online environments and maintain community guidelines. The API is designed to be integrated into applications, websites, and platforms, providing real-time content moderation to reduce the spread of harmful or offensive material.\n\nLearn more from the following resources:",
+    "title": "API de Moderación de OpenAI",
+    "description": "La API de Moderación de OpenAI ayuda a detectar y filtrar contenido dañino analizando el texto en busca de problemas como discurso de odio, violencia, autolesiones y contenido para adultos. Utiliza modelos de aprendizaje automático para identificar lenguaje inapropiado o inseguro, lo que permite a los desarrolladores crear entornos en línea más seguros y mantener las directrices de la comunidad. La API está diseñada para integrarse en aplicaciones, sitios web y plataformas, proporcionando moderación de contenido en tiempo real para reducir la propagación de material dañino u ofensivo.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
-        "title": "Moderation",
+        "title": "Moderación",
         "url": "https://platform.openai.com/docs/guides/moderation",
         "type": "article"
       },
       {
-        "title": "How to user the moderation API",
+        "title": "Cómo usar la API de moderación",
         "url": "https://cookbook.openai.com/examples/how_to_use_moderation",
         "type": "article"
       }
     ]
   },
   "4Q5x2VCXedAWISBXUIyin": {
-    "title": "Adding end-user IDs in prompts",
-    "description": "Sending end-user IDs in your requests can be a useful tool to help OpenAI monitor and detect abuse. This allows OpenAI to provide your team with more actionable feedback in the event that we detect any policy violations in your application.\n\nVisit the following resources to learn more:",
+    "title": "Adición de ID de usuario final en los prompts",
+    "description": "Enviar ID de usuario final en tus solicitudes puede ser una herramienta útil para ayudar a OpenAI a monitorear y detectar abusos. Esto permite a OpenAI proporcionar a tu equipo comentarios más procesables en caso de que detectemos alguna violación de política en tu aplicación.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "Sending End-user IDs - OpenAI",
+        "title": "Envío de ID de Usuario Final - OpenAI",
         "url": "https://platform.openai.com/docs/guides/safety-best-practices/end-user-ids",
         "type": "article"
       }
     ]
   },
   "qmx6OHqx4_0JXVIv8dASp": {
-    "title": "Robust prompt engineering",
-    "description": "Robust prompt engineering involves carefully crafting inputs to guide AI models toward producing accurate, relevant, and reliable outputs. It focuses on minimizing ambiguity and maximizing clarity by providing specific instructions, examples, or structured formats. Effective prompts anticipate potential issues, such as misinterpretation or inappropriate responses, and address them through testing and refinement. This approach enhances the consistency and quality of the model's behavior, making it especially useful for complex tasks like multi-step reasoning, content generation, and interactive systems.\n\nLearn more from the following resources:",
+    "title": "Ingeniería de prompts robusta",
+    "description": "La ingeniería de prompts robusta implica elaborar cuidadosamente las entradas para guiar a los modelos de IA hacia la producción de resultados precisos, relevantes y confiables. Se enfoca en minimizar la ambigüedad y maximizar la claridad proporcionando instrucciones específicas, ejemplos o formatos estructurados. Los prompts efectivos anticipan problemas potenciales, como una mala interpretación o respuestas inapropiadas, y los abordan mediante pruebas y refinamiento. Este enfoque mejora la consistencia y la calidad del comportamiento del modelo, lo que lo hace especialmente útil para tareas complejas como el razonamiento de varios pasos, la generación de contenido y los sistemas interactivos.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
-        "title": "Building Robust Prompt Engineering Capability",
+        "title": "Construyendo una Capacidad Robusta de Ingeniería de Prompts",
         "url": "https://aimresearch.co/product/building-robust-prompt-engineering-capability",
         "type": "article"
       },
       {
-        "title": "Effective Prompt Engineering: A Comprehensive Guide",
+        "title": "Ingeniería de Prompts Efectiva: Una Guía Completa",
         "url": "https://medium.com/@nmurugs/effective-prompt-engineering-a-comprehensive-guide-803160c571ed",
         "type": "article"
       }
     ]
   },
   "t1SObMWkDZ1cKqNNlcd9L": {
-    "title": "Know your Customers / Usecases",
-    "description": "To know your customer means deeply understanding the needs, behaviors, and expectations of your target users. This ensures the tools you create are tailored precisely for their intended purpose, while also being designed to prevent misuse or unintended applications. By clearly defining the tool’s functionality and boundaries, you can align its features with the users’ goals while incorporating safeguards that limit its use in contexts it wasn’t designed for. This approach enhances both the tool’s effectiveness and safety, reducing the risk of improper use.\n\nLearn more from the following resources:",
+    "title": "Conoce a tus Clientes / Casos de Uso",
+    "description": "Conocer a tu cliente significa comprender profundamente las necesidades, comportamientos y expectativas de tus usuarios objetivo. Esto asegura que las herramientas que crees estén diseñadas con precisión para su propósito previsto, al mismo tiempo que están diseñadas para prevenir el mal uso o aplicaciones no deseadas. Al definir claramente la funcionalidad y los límites de la herramienta, puedes alinear sus características con los objetivos de los usuarios mientras incorporas salvaguardas que limitan su uso en contextos para los que no fue diseñada. Este enfoque mejora tanto la efectividad como la seguridad de la herramienta, reduciendo el riesgo de uso indebido.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
-        "title": "Assigning Roles",
+        "title": "Asignación de Roles",
         "url": "https://learnprompting.org/docs/basics/roles",
         "type": "article"
       }
     ]
   },
   "ONLDyczNacGVZGojYyJrU": {
-    "title": "Constraining outputs and inputs",
-    "description": "Constraining outputs and inputs in AI models refers to implementing limits or rules that guide both the data the model processes (inputs) and the results it generates (outputs). Input constraints ensure that only valid, clean, and well-formed data enters the model, which helps to reduce errors and improve performance. This can include setting data type restrictions, value ranges, or specific formats. Output constraints, on the other hand, ensure that the model produces appropriate, safe, and relevant results, often by limiting output length, specifying answer formats, or applying filters to avoid harmful or biased responses. These constraints are crucial for improving model safety, alignment, and utility in practical applications.\n\nLearn more from the following resources:",
+    "title": "Restricción de salidas y entradas",
+    "description": "La restricción de salidas y entradas en los modelos de IA se refiere a la implementación de límites o reglas que guían tanto los datos que procesa el modelo (entradas) como los resultados que genera (salidas). Las restricciones de entrada garantizan que solo entren en el modelo datos válidos, limpios y bien formados, lo que ayuda a reducir errores y mejorar el rendimiento. Esto puede incluir el establecimiento de restricciones de tipo de datos, rangos de valores o formatos específicos. Las restricciones de salida, por otro lado, garantizan que el modelo produzca resultados apropiados, seguros y relevantes, a menudo limitando la longitud de la salida, especificando formatos de respuesta o aplicando filtros para evitar respuestas dañinas o sesgadas. Estas restricciones son cruciales para mejorar la seguridad, la alineación y la utilidad del modelo en aplicaciones prácticas.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
-        "title": "Preventing Prompt Injection",
+        "title": "Prevención de la Inyección de Prompts",
         "url": "https://learnprompting.org/docs/prompt_hacking/defensive_measures/introduction",
         "type": "article"
       },
       {
-        "title": "Introducing Structured Outputs in the API - OpenAI",
+        "title": "Presentación de Salidas Estructuradas en la API - OpenAI",
         "url": "https://openai.com/index/introducing-structured-outputs-in-the-api/",
         "type": "article"
       }
     ]
   },
   "a_3SabylVqzzOyw3tZN5f": {
-    "title": "OpenSource AI",
-    "description": "Open-source AI refers to AI models, tools, and frameworks that are freely available for anyone to use, modify, and distribute. Examples include TensorFlow, PyTorch, and models like BERT and Stable Diffusion. Open-source AI fosters transparency, collaboration, and innovation by allowing developers to inspect code, adapt models for specific needs, and contribute improvements. This approach accelerates the development of AI technologies, enabling faster experimentation and reducing dependency on proprietary solutions.\n\nLearn more from the following resources:",
+    "title": "IA de Código Abierto",
+    "description": "La IA de código abierto se refiere a modelos, herramientas y marcos de IA que están disponibles gratuitamente para que cualquiera los use, modifique y distribuya. Ejemplos incluyen TensorFlow, PyTorch y modelos como BERT y Stable Diffusion. La IA de código abierto fomenta la transparencia, la colaboración y la innovación al permitir a los desarrolladores inspeccionar el código, adaptar modelos para necesidades específicas y contribuir con mejoras. Este enfoque acelera el desarrollo de tecnologías de IA, permitiendo una experimentación más rápida y reduciendo la dependencia de soluciones propietarias.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
-        "title": "Open Source AI Is the Path Forward",
+        "title": "La IA de Código Abierto es el Camino a Seguir",
         "url": "https://about.fb.com/news/2024/07/open-source-ai-is-the-path-forward/",
         "type": "article"
       },
       {
-        "title": "Should You Use Open Source Large Language Models?",
+        "title": "¿Deberías Usar Modelos de Lenguaje Grandes de Código Abierto?",
         "url": "https://www.youtube.com/watch?v=y9k-U9AuDeM",
         "type": "video"
       }
     ]
   },
   "RBwGsq9DngUsl8PrrCbqx": {
-    "title": "Open vs Closed Source Models",
-    "description": "Open-source models are freely available for customization and collaboration, promoting transparency and flexibility, while closed-source models are proprietary, offering ease of use but limiting modification and transparency.\n\nLearn more from the following resources:",
+    "title": "Modelos de Código Abierto vs Cerrado",
+    "description": "Los modelos de código abierto están disponibles gratuitamente para personalización y colaboración, promoviendo la transparencia y la flexibilidad, mientras que los modelos de código cerrado son propietarios, ofreciendo facilidad de uso pero limitando la modificación y la transparencia.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
-        "title": "OpenAI vs. Open Source LLM",
+        "title": "OpenAI vs. LLM de Código Abierto",
         "url": "https://ubiops.com/openai-vs-open-source-llm/",
         "type": "article"
       },
       {
-        "title": "Open-Source vs Closed-Source LLMs",
+        "title": "LLMs de Código Abierto vs Código Cerrado",
         "url": "https://www.youtube.com/watch?v=710PDpuLwOc",
         "type": "video"
       }
     ]
   },
   "97eu-XxYUH9pYbD_KjAtA": {
-    "title": "Popular Open Source Models",
-    "description": "Open-source large language models (LLMs) are models whose source code and architecture are publicly available for use, modification, and distribution. They are built using machine learning algorithms that process and generate human-like text, and being open-source, they promote transparency, innovation, and community collaboration in their development and application.\n\nLearn more from the following resources:",
+    "title": "Modelos Populares de Código Abierto",
+    "description": "Los modelos de lenguaje grandes (LLM) de código abierto son modelos cuyo código fuente y arquitectura están disponibles públicamente para su uso, modificación y distribución. Se construyen utilizando algoritmos de aprendizaje automático que procesan y generan texto similar al humano y, al ser de código abierto, promueven la transparencia, la innovación y la colaboración comunitaria en su desarrollo y aplicación.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
-        "title": "The Best Large Language Models (LLMs) in 2024",
+        "title": "Los Mejores Modelos de Lenguaje Grandes (LLMs) en 2024",
         "url": "https://zapier.com/blog/best-llm/",
         "type": "article"
       },
       {
-        "title": "8 Top Open-Source LLMs for 2024 and Their Uses",
+        "title": "Los 8 Mejores LLMs de Código Abierto para 2024 y sus Usos",
         "url": "https://www.datacamp.com/blog/top-open-source-llms",
         "type": "article"
       }
@@ -805,10 +805,10 @@
   },
   "v99C5Bml2a6148LCJ9gy9": {
     "title": "Hugging Face",
-    "description": "Hugging Face is a leading AI company and open-source platform that provides tools, models, and libraries for natural language processing (NLP), computer vision, and other machine learning tasks. It is best known for its \"Transformers\" library, which simplifies the use of pre-trained models like BERT, GPT, T5, and CLIP, making them accessible for tasks such as text classification, translation, summarization, and image recognition.\n\nLearn more from the following resources:",
+    "description": "Hugging Face es una empresa líder en IA y una plataforma de código abierto que proporciona herramientas, modelos y bibliotecas para el procesamiento del lenguaje natural (NLP), la visión por computadora y otras tareas de aprendizaje automático. Es más conocida por su biblioteca \"Transformers\", que simplifica el uso de modelos preentrenados como BERT, GPT, T5 y CLIP, haciéndolos accesibles para tareas como clasificación de texto, traducción, resumen y reconocimiento de imágenes.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
-        "title": "Hugging Face Official Video Course",
+        "title": "Curso Oficial en Video de Hugging Face",
         "url": "https://www.youtube.com/watch?v=00GKzGyWFEs&list=PLo2EIpI_JMQvWfQndUesu0nPBAtZ9gP1o",
         "type": "course"
       },
@@ -818,15 +818,15 @@
         "type": "article"
       },
       {
-        "title": "What is Hugging Face? - Machine Learning Hub Explained",
+        "title": "¿Qué es Hugging Face? - Explicación del Centro de Aprendizaje Automático",
         "url": "https://www.youtube.com/watch?v=1AUjKfpRZVo",
         "type": "video"
       }
     ]
   },
   "YLOdOvLXa5Fa7_mmuvKEi": {
-    "title": "Hugging Face Hub",
-    "description": "The Hugging Face Hub is a comprehensive platform that hosts over 900,000 machine learning models, 200,000 datasets, and 300,000 demo applications, facilitating collaboration and sharing within the AI community. It serves as a central repository where users can discover, upload, and experiment with various models and datasets across multiple domains, including natural language processing, computer vision, and audio tasks. It also supports version control.\n\nLearn more from the following resources:",
+    "title": "Hub de Hugging Face",
+    "description": "El Hub de Hugging Face es una plataforma integral que aloja más de 900,000 modelos de aprendizaje automático, 200,000 conjuntos de datos y 300,000 aplicaciones de demostración, facilitando la colaboración y el intercambio dentro de la comunidad de IA. Sirve como un repositorio central donde los usuarios pueden descubrir, cargar y experimentar con diversos modelos y conjuntos de datos en múltiples dominios, incluido el procesamiento del lenguaje natural, la visión por computadora y las tareas de audio. También admite el control de versiones.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
         "title": "nlp-official",
@@ -834,44 +834,44 @@
         "type": "course"
       },
       {
-        "title": "Hugging Face Documentation",
+        "title": "Documentación de Hugging Face",
         "url": "https://huggingface.co/docs/hub/en/index",
         "type": "article"
       }
     ]
   },
   "YKIPOiSj_FNtg0h8uaSMq": {
-    "title": "Hugging Face Tasks",
-    "description": "Hugging Face supports text classification, named entity recognition, question answering, summarization, and translation. It also extends to multimodal tasks that involve both text and images, such as visual question answering (VQA) and image-text matching. Each task is done by various pre-trained models that can be easily accessed and fine-tuned through the Hugging Face library.\n\nLearn more from the following resources:",
+    "title": "Tareas de Hugging Face",
+    "description": "Hugging Face admite clasificación de texto, reconocimiento de entidades nombradas, respuesta a preguntas, resumen y traducción. También se extiende a tareas multimodales que involucran tanto texto como imágenes, como respuesta visual a preguntas (VQA) y coincidencia de texto e imagen. Cada tarea se realiza mediante varios modelos preentrenados a los que se puede acceder y ajustar fácilmente a través de la biblioteca Hugging Face.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
-        "title": "Task and Model",
+        "title": "Tarea y Modelo",
         "url": "https://huggingface.co/learn/computer-vision-course/en/unit4/multimodal-models/tasks-models-part1",
         "type": "article"
       },
       {
-        "title": "Task Summary",
+        "title": "Resumen de Tareas",
         "url": "https://huggingface.co/docs/transformers/v4.14.1/en/task_summary",
         "type": "article"
       },
       {
-        "title": "Task Manager",
+        "title": "Administrador de Tareas",
         "url": "https://huggingface.co/docs/optimum/en/exporters/task_manager",
         "type": "article"
       }
     ]
   },
   "3kRTzlLNBnXdTsAEXVu_M": {
-    "title": "Inference SDK",
-    "description": "The Hugging Face Inference SDK is a powerful tool that allows developers to easily integrate and run inference on large language models hosted on the Hugging Face Hub. By using the `InferenceClient`, users can make API calls to various models for tasks such as text generation, image creation, and more. The SDK supports both synchronous and asynchronous operations thus compatible with existing workflows.\n\nLearn more from the following resources:",
+    "title": "SDK de Inferencia",
+    "description": "El SDK de Inferencia de Hugging Face es una herramienta potente que permite a los desarrolladores integrar y ejecutar fácilmente la inferencia en modelos de lenguaje grandes alojados en el Hugging Face Hub. Al usar `InferenceClient`, los usuarios pueden realizar llamadas API a varios modelos para tareas como generación de texto, creación de imágenes y más. El SDK admite operaciones síncronas y asíncronas, por lo que es compatible con los flujos de trabajo existentes.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
-        "title": "Inference",
+        "title": "Inferencia",
         "url": "https://huggingface.co/docs/huggingface_hub/en/package_reference/inference_client",
         "type": "article"
       },
       {
-        "title": "Endpoint Setup",
+        "title": "Configuración del Punto Final",
         "url": "https://www.npmjs.com/package/@huggingface/inference",
         "type": "article"
       }
@@ -879,15 +879,15 @@
   },
   "bGLrbpxKgENe2xS1eQtdh": {
     "title": "Transformers.js",
-    "description": "Transformers.js is a JavaScript library that enables transformer models, like those from Hugging Face, to run directly in the browser or Node.js, without needing cloud services. It supports tasks such as text generation, sentiment analysis, and translation within web apps or server-side scripts. Using WebAssembly (Wasm) and efficient JavaScript, Transformers.js offers powerful NLP capabilities with low latency, enhanced privacy, and offline functionality, making it ideal for real-time, interactive applications where local processing is essential for performance and security.\n\nLearn more from the following resources:",
+    "description": "Transformers.js es una biblioteca de JavaScript que permite que los modelos de transformadores, como los de Hugging Face, se ejecuten directamente en el navegador o Node.js, sin necesidad de servicios en la nube. Admite tareas como generación de texto, análisis de sentimientos y traducción dentro de aplicaciones web o scripts del lado del servidor. Usando WebAssembly (Wasm) y JavaScript eficiente, Transformers.js ofrece potentes capacidades de NLP con baja latencia, privacidad mejorada y funcionalidad sin conexión, lo que lo hace ideal para aplicaciones interactivas en tiempo real donde el procesamiento local es esencial para el rendimiento y la seguridad.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
-        "title": "Transformers.js on Hugging Face",
+        "title": "Transformers.js en Hugging Face",
         "url": "https://huggingface.co/docs/transformers.js/en/index",
         "type": "article"
       },
       {
-        "title": "How Transformer.js Can Help You Create Smarter AI In Your Browser",
+        "title": "Cómo Transformer.js Puede Ayudarte a Crear una IA Más Inteligente en tu Navegador",
         "url": "https://www.youtube.com/watch?v=MNJHu9zjpqg",
         "type": "video"
       }
@@ -895,7 +895,7 @@
   },
   "rTT2UnvqFO3GH6ThPLEjO": {
     "title": "Ollama",
-    "description": "Ollama is a platform that offers large language models (LLMs) designed to run locally on personal devices, enabling AI functionality without relying on cloud services. It focuses on privacy, performance, and ease of use by allowing users to deploy models directly on laptops, desktops, or edge devices, providing fast, offline AI capabilities. With tools like the Ollama SDK, developers can integrate these models into their applications for tasks such as text generation, summarization, and more, benefiting from reduced latency, greater data control, and seamless local processing.\n\nLearn more from the following resources:",
+    "description": "Ollama es una plataforma que ofrece modelos de lenguaje grandes (LLM) diseñados para ejecutarse localmente en dispositivos personales, lo que permite la funcionalidad de IA sin depender de servicios en la nube. Se centra en la privacidad, el rendimiento y la facilidad de uso al permitir a los usuarios implementar modelos directamente en computadoras portátiles, de escritorio o dispositivos de borde, proporcionando capacidades de IA rápidas y sin conexión. Con herramientas como el SDK de Ollama, los desarrolladores pueden integrar estos modelos en sus aplicaciones para tareas como generación de texto, resumen y más, beneficiándose de una latencia reducida, un mayor control de datos y un procesamiento local sin interrupciones.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
         "title": "Ollama",
@@ -903,175 +903,175 @@
         "type": "article"
       },
       {
-        "title": "Ollama: Easily run LLMs locally",
+        "title": "Ollama: Ejecuta LLMs localmente de forma sencilla",
         "url": "https://klu.ai/glossary/ollama",
         "type": "article"
       },
       {
-        "title": "What is Ollama? Running Local LLMs Made Simple",
+        "title": "¿Qué es Ollama? Ejecución Local de LLMs Simplificada",
         "url": "https://www.youtube.com/watch?v=5RIOQuHOihY",
         "type": "video"
       }
     ]
   },
   "ro3vY_sp6xMQ-hfzO-rc1": {
-    "title": "Ollama Models",
-    "description": "Ollama provides a collection of large language models (LLMs) designed to run locally on personal devices, enabling privacy-focused and efficient AI applications without relying on cloud services. These models can perform tasks like text generation, translation, summarization, and question answering, similar to popular models like GPT. Ollama emphasizes ease of use, offering models that are optimized for lower resource consumption, making it possible to deploy AI capabilities directly on laptops or edge devices.\n\nLearn more from the following resources:",
+    "title": "Modelos Ollama",
+    "description": "Ollama proporciona una colección de modelos de lenguaje grandes (LLM) diseñados para ejecutarse localmente en dispositivos personales, lo que permite aplicaciones de IA eficientes y centradas en la privacidad sin depender de servicios en la nube. Estos modelos pueden realizar tareas como generación de texto, traducción, resumen y respuesta a preguntas, de forma similar a modelos populares como GPT. Ollama enfatiza la facilidad de uso, ofreciendo modelos optimizados para un menor consumo de recursos, lo que permite implementar capacidades de IA directamente en computadoras portátiles o dispositivos de borde.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
-        "title": "Ollama Model Library",
+        "title": "Biblioteca de Modelos Ollama",
         "url": "https://ollama.com/library",
         "type": "article"
       },
       {
-        "title": "What are the different types of models? Ollama Course",
+        "title": "¿Cuáles son los diferentes tipos de modelos? Curso Ollama",
         "url": "https://www.youtube.com/watch?v=f4tXwCNP1Ac",
         "type": "video"
       }
     ]
   },
   "TsG_I7FL-cOCSw8gvZH3r": {
-    "title": "Ollama SDK",
-    "description": "The Ollama SDK is a community-driven tool that allows developers to integrate and run large language models (LLMs) locally through a simple API. Enabling users to easily import the Ollama provider and create customized instances for various models, such as Llama 2 and Mistral. The SDK supports functionalities like `text generation` and `embeddings`, making it versatile for applications ranging from `chatbots` to `content generation`. Also Ollama SDK enhances privacy and control over data while offering seamless integration with existing workflows.\n\nLearn more from the following resources:",
+    "title": "SDK de Ollama",
+    "description": "El SDK de Ollama es una herramienta impulsada por la comunidad que permite a los desarrolladores integrar y ejecutar modelos de lenguaje grandes (LLM) localmente a través de una API simple. Permite a los usuarios importar fácilmente el proveedor de Ollama y crear instancias personalizadas para varios modelos, como Llama 2 y Mistral. El SDK admite funcionalidades como `generación de texto` y `embeddings`, lo que lo hace versátil para aplicaciones que van desde `chatbots` hasta `generación de contenido`. Además, el SDK de Ollama mejora la privacidad y el control sobre los datos al tiempo que ofrece una integración perfecta con los flujos de trabajo existentes.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
-        "title": "SDK Provider",
+        "title": "Proveedor de SDK",
         "url": "https://sdk.vercel.ai/providers/community-providers/ollama",
         "type": "article"
       },
       {
-        "title": "Beginner's Guide",
+        "title": "Guía para Principiantes",
         "url": "https://dev.to/jayantaadhikary/using-the-ollama-api-to-run-llms-and-generate-responses-locally-18b7",
         "type": "article"
       },
       {
-        "title": "Setup",
+        "title": "Configuración",
         "url": "https://klu.ai/glossary/ollama",
         "type": "article"
       }
     ]
   },
   "--ig0Ume_BnXb9K2U7HJN": {
-    "title": "What are Embeddings",
-    "description": "Embeddings are dense, numerical vector representations of data, such as words, sentences, images, or audio, that capture their semantic meaning and relationships. By converting data into fixed-length vectors, embeddings allow machine learning models to process and understand the data more effectively. For example, word embeddings represent similar words with similar vectors, enabling tasks like semantic search, recommendation systems, and clustering. Embeddings make it easier to compare, search, and analyze complex, unstructured data by mapping similar items close together in a high-dimensional space.\n\nVisit the following resources to learn more:",
+    "title": "¿Qué son los Embeddings?",
+    "description": "Los embeddings son representaciones vectoriales numéricas densas de datos, como palabras, oraciones, imágenes o audio, que capturan su significado semántico y sus relaciones. Al convertir los datos en vectores de longitud fija, los embeddings permiten que los modelos de aprendizaje automático procesen y comprendan los datos de manera más eficaz. Por ejemplo, los embeddings de palabras representan palabras similares con vectores similares, lo que permite tareas como la búsqueda semántica, los sistemas de recomendación y la agrupación. Los embeddings facilitan la comparación, búsqueda y análisis de datos complejos y no estructurados al mapear elementos similares juntos en un espacio de alta dimensión.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "Introducing Text and Code Embeddings",
+        "title": "Presentación de Embeddings de Texto y Código",
         "url": "https://openai.com/index/introducing-text-and-code-embeddings/",
         "type": "article"
       },
       {
-        "title": "What are Embeddings",
+        "title": "¿Qué son los Embeddings?",
         "url": "https://www.cloudflare.com/learning/ai/what-are-embeddings/",
         "type": "article"
       }
     ]
   },
   "eMfcyBxnMY_l_5-8eg6sD": {
-    "title": "Semantic Search",
-    "description": "Embeddings are used for semantic search by converting text, such as queries and documents, into high-dimensional vectors that capture the underlying meaning and context, rather than just exact words. These embeddings represent the semantic relationships between words or phrases, allowing the system to understand the query’s intent and retrieve relevant information, even if the exact terms don’t match.\n\nLearn more from the following resources:",
+    "title": "Búsqueda Semántica",
+    "description": "Los embeddings se utilizan para la búsqueda semántica convirtiendo texto, como consultas y documentos, en vectores de alta dimensión que capturan el significado y el contexto subyacentes, en lugar de solo palabras exactas. Estos embeddings representan las relaciones semánticas entre palabras o frases, lo que permite al sistema comprender la intención de la consulta y recuperar información relevante, incluso si los términos exactos no coinciden.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
-        "title": "What is Semantic Search?",
+        "title": "¿Qué es la Búsqueda Semántica?",
         "url": "https://www.elastic.co/what-is/semantic-search",
         "type": "article"
       },
       {
-        "title": "What is Semantic Search? - Cohere",
+        "title": "¿Qué es la Búsqueda Semántica? - Cohere",
         "url": "https://www.youtube.com/watch?v=fFt4kR4ntAA",
         "type": "video"
       }
     ]
   },
   "HQe9GKy3p0kTUPxojIfSF": {
-    "title": "Recommendation Systems",
-    "description": "In the context of embeddings, recommendation systems use vector representations to capture similarities between items, such as products or content. By converting items and user preferences into embeddings, these systems can measure how closely related different items are based on vector proximity, allowing them to recommend similar products or content based on a user's past interactions. This approach improves recommendation accuracy and efficiency by enabling meaningful, scalable comparisons of complex data.\n\nLearn more from the following resources:",
+    "title": "Sistemas de Recomendación",
+    "description": "En el contexto de los embeddings, los sistemas de recomendación utilizan representaciones vectoriales para capturar similitudes entre elementos, como productos o contenido. Al convertir elementos y preferencias de usuario en embeddings, estos sistemas pueden medir cuán estrechamente relacionados están diferentes elementos en función de la proximidad vectorial, lo que les permite recomendar productos o contenido similares en función de las interacciones pasadas de un usuario. Este enfoque mejora la precisión y eficiencia de las recomendaciones al permitir comparaciones significativas y escalables de datos complejos.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
-        "title": "What Role does AI Play in Recommendation Systems and Engines?",
+        "title": "¿Qué Papel Juega la IA en los Sistemas y Motores de Recomendación?",
         "url": "https://www.algolia.com/blog/ai/what-role-does-ai-play-in-recommendation-systems-and-engines/",
         "type": "article"
       },
       {
-        "title": "What is a Recommendation Engine?",
+        "title": "¿Qué es un Motor de Recomendación?",
         "url": "https://www.ibm.com/think/topics/recommendation-engine",
         "type": "article"
       }
     ]
   },
   "AglWJ7gb9rTT2rMkstxtk": {
-    "title": "Anomaly Detection",
-    "description": "Anomaly detection with embeddings works by transforming data, such as text, images, or time-series data, into vector representations that capture their patterns and relationships. In this high-dimensional space, similar data points are positioned close together, while anomalies stand out as those that deviate significantly from the typical distribution. This approach is highly effective for detecting outliers in tasks like fraud detection, network security, and quality control.\n\nLearn more from the following resources:",
+    "title": "Detección de Anomalías",
+    "description": "La detección de anomalías con embeddings funciona transformando datos, como texto, imágenes o datos de series temporales, en representaciones vectoriales que capturan sus patrones y relaciones. En este espacio de alta dimensión, los puntos de datos similares se posicionan juntos, mientras que las anomalías se destacan como aquellas que se desvían significativamente de la distribución típica. Este enfoque es altamente efectivo para detectar valores atípicos en tareas como detección de fraude, seguridad de redes y control de calidad.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
-        "title": "Anomaly in Embeddings",
+        "title": "Anomalía en Embeddings",
         "url": "https://ai.google.dev/gemini-api/tutorials/anomaly_detection",
         "type": "article"
       }
     ]
   },
   "06Xta-OqSci05nV2QMFdF": {
-    "title": "Data Classification",
-    "description": "Once data is embedded, a classification algorithm, such as a neural network or a logistic regression model, can be trained on these embeddings to classify the data into different categories. The advantage of using embeddings is that they capture underlying relationships and similarities between data points, even if the raw data is complex or high-dimensional, improving classification accuracy in tasks like text classification, image categorization, and recommendation systems.\n\nLearn more from the following resources:",
+    "title": "Clasificación de Datos",
+    "description": "Una vez que los datos están incrustados, se puede entrenar un algoritmo de clasificación, como una red neuronal o un modelo de regresión logística, en estos embeddings para clasificar los datos en diferentes categorías. La ventaja de usar embeddings es que capturan relaciones y similitudes subyacentes entre los puntos de datos, incluso si los datos sin procesar son complejos o de alta dimensión, lo que mejora la precisión de la clasificación en tareas como la clasificación de texto, la categorización de imágenes y los sistemas de recomendación.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
-        "title": "What Is Data Classification?",
+        "title": "¿Qué es la Clasificación de Datos?",
         "url": "https://www.paloaltonetworks.com/cyberpedia/data-classification",
         "type": "article"
       },
       {
-        "title": "Text Embeddings, Classification, and Semantic Search (w/ Python Code)",
+        "title": "Embeddings de Texto, Clasificación y Búsqueda Semántica (con Código Python)",
         "url": "https://www.youtube.com/watch?v=sNa_uiqSlJo",
         "type": "video"
       }
     ]
   },
   "l6priWeJhbdUD5tJ7uHyG": {
-    "title": "Open AI Embeddings API",
-    "description": "The OpenAI Embeddings API allows developers to generate dense vector representations of text, which capture semantic meaning and relationships. These embeddings can be used for various tasks, such as semantic search, recommendation systems, and clustering, by enabling the comparison of text based on similarity in vector space. The API supports easy integration and scalability, making it possible to handle large datasets and perform tasks like finding similar documents, organizing content, or building recommendation engines. Learn more from the following resources:",
+    "title": "API de Embeddings de OpenAI",
+    "description": "La API de Embeddings de OpenAI permite a los desarrolladores generar representaciones vectoriales densas de texto, que capturan el significado semántico y las relaciones. Estos embeddings se pueden utilizar para diversas tareas, como búsqueda semántica, sistemas de recomendación y agrupación, al permitir la comparación de texto basada en la similitud en el espacio vectorial. La API admite una fácil integración y escalabilidad, lo que permite manejar grandes conjuntos de datos y realizar tareas como encontrar documentos similares, organizar contenido o construir motores de recomendación. Aprende más de los siguientes recursos:",
     "links": [
       {
-        "title": "OpenAI Embeddings API",
+        "title": "API de Embeddings de OpenAI",
         "url": "https://platform.openai.com/docs/api-reference/embeddings/create",
         "type": "article"
       },
       {
-        "title": "Master OpenAI Embedding API",
+        "title": "Domina la API de Embedding de OpenAI",
         "url": "https://www.youtube.com/watch?v=9oCS-VQupoc",
         "type": "video"
       }
     ]
   },
   "y0qD5Kb4Pf-ymIwW-tvhX": {
-    "title": "Open AI Embedding Models",
-    "description": "OpenAI's embedding models convert text into dense vector representations that capture semantic meaning, allowing for efficient similarity searches, clustering, and recommendations. These models are commonly used for tasks like semantic search, where similar phrases are mapped to nearby points in a vector space, and for building recommendation systems by comparing embeddings to find related content. OpenAI's embedding models offer versatility, supporting a range of applications from document retrieval to content classification, and can be easily integrated through the OpenAI API for scalable and efficient deployment.\n\nLearn more from the following resources:",
+    "title": "Modelos de Embedding de OpenAI",
+    "description": "Los modelos de embedding de OpenAI convierten texto en representaciones vectoriales densas que capturan el significado semántico, lo que permite búsquedas de similitud, agrupamiento y recomendaciones eficientes. Estos modelos se utilizan comúnmente para tareas como la búsqueda semántica, donde frases similares se mapean a puntos cercanos en un espacio vectorial, y para construir sistemas de recomendación comparando embeddings para encontrar contenido relacionado. Los modelos de embedding de OpenAI ofrecen versatilidad, admitiendo una variedad de aplicaciones desde la recuperación de documentos hasta la clasificación de contenido, y se pueden integrar fácilmente a través de la API de OpenAI para una implementación escalable y eficiente.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
-        "title": "OpenAI Embedding Models",
+        "title": "Modelos de Embedding de OpenAI",
         "url": "https://platform.openai.com/docs/guides/embeddings/embedding-models",
         "type": "article"
       },
       {
-        "title": "OpenAI Embeddings Explained in 5 Minutes",
+        "title": "Embeddings de OpenAI Explicados en 5 Minutos",
         "url": "https://www.youtube.com/watch?v=8kJStTRuMcs",
         "type": "video"
       }
     ]
   },
   "4GArjDYipit4SLqKZAWDf": {
-    "title": "Pricing Considerations",
-    "description": "The pricing for the OpenAI Embedding API is based on the number of tokens processed and the specific embedding model used. Costs are determined by the total tokens needed to generate embeddings, so longer texts will result in higher charges. To manage costs, developers can optimize by shortening inputs or batching requests. Additionally, selecting the right embedding model for your performance and budget requirements, along with monitoring token usage, can help control expenses.\n\nVisit the following resources to learn more:",
+    "title": "Consideraciones de Precios",
+    "description": "El precio de la API de Embedding de OpenAI se basa en el número de tokens procesados y el modelo de embedding específico utilizado. Los costos se determinan por el total de tokens necesarios para generar embeddings, por lo que los textos más largos resultarán en cargos más altos. Para gestionar los costos, los desarrolladores pueden optimizar acortando las entradas o agrupando las solicitudes. Además, seleccionar el modelo de embedding adecuado para tus requisitos de rendimiento y presupuesto, junto con el monitoreo del uso de tokens, puede ayudar a controlar los gastos.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "OpenAI Pricing",
+        "title": "Precios de OpenAI",
         "url": "https://openai.com/api/pricing/",
         "type": "article"
       }
     ]
   },
   "apVYIV4EyejPft25oAvdI": {
-    "title": "Open-Source Embeddings",
-    "description": "Open-source embeddings are pre-trained vector representations of data, usually text, that are freely available for use and modification. These embeddings capture semantic meanings, making them useful for tasks like semantic search, text classification, and clustering. Examples include Word2Vec, GloVe, and FastText, which represent words as vectors based on their context in large corpora, and more advanced models like Sentence-BERT and CLIP that provide embeddings for sentences and images. Open-source embeddings allow developers to leverage pre-trained models without starting from scratch, enabling faster development and experimentation in natural language processing and other AI applications.\n\nLearn more from the following resources:",
+    "title": "Embeddings de Código Abierto",
+    "description": "Los embeddings de código abierto son representaciones vectoriales preentrenadas de datos, generalmente texto, que están disponibles gratuitamente para su uso y modificación. Estos embeddings capturan significados semánticos, lo que los hace útiles para tareas como la búsqueda semántica, la clasificación de texto y la agrupación. Ejemplos incluyen Word2Vec, GloVe y FastText, que representan palabras como vectores basados en su contexto en grandes corpus, y modelos más avanzados como Sentence-BERT y CLIP que proporcionan embeddings para oraciones e imágenes. Los embeddings de código abierto permiten a los desarrolladores aprovechar modelos preentrenados sin empezar desde cero, lo que permite un desarrollo y experimentación más rápidos en el procesamiento del lenguaje natural y otras aplicaciones de IA.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
         "title": "Embeddings",
@@ -1079,65 +1079,65 @@
         "type": "article"
       },
       {
-        "title": "A Guide to Open-Source Embedding Models",
+        "title": "Una Guía de Modelos de Embedding de Código Abierto",
         "url": "https://www.bentoml.com/blog/a-guide-to-open-source-embedding-models",
         "type": "article"
       }
     ]
   },
   "ZV_V6sqOnRodgaw4mzokC": {
-    "title": "Sentence Transformers",
-    "description": "Sentence Transformers are a type of model designed to generate high-quality embeddings for sentences, allowing them to capture the semantic meaning of text. Unlike traditional word embeddings, which represent individual words, Sentence Transformers understand the context of entire sentences, making them ideal for tasks that require semantic similarity, such as sentence clustering, semantic search, and paraphrase detection. Built on top of transformer models like BERT and RoBERTa, they convert sentences into dense vectors, where similar sentences are placed closer together in vector space.\n\nLearn more from the following resources:",
+    "title": "Transformadores de Oraciones",
+    "description": "Los Transformadores de Oraciones son un tipo de modelo diseñado para generar embeddings de alta calidad para oraciones, lo que les permite capturar el significado semántico del texto. A diferencia de los embeddings de palabras tradicionales, que representan palabras individuales, los Transformadores de Oraciones comprenden el contexto de oraciones enteras, lo que los hace ideales para tareas que requieren similitud semántica, como la agrupación de oraciones, la búsqueda semántica y la detección de paráfrasis. Construidos sobre modelos de transformadores como BERT y RoBERTa, convierten oraciones en vectores densos, donde oraciones similares se colocan más cerca en el espacio vectorial.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
-        "title": "What is BERT?",
+        "title": "¿Qué es BERT?",
         "url": "https://h2o.ai/wiki/bert/",
         "type": "article"
       },
       {
-        "title": "SentenceTransformers Documentation",
+        "title": "Documentación de SentenceTransformers",
         "url": "https://sbert.net/",
         "type": "article"
       },
       {
-        "title": "Using Sentence Transformers at Hugging Face",
+        "title": "Uso de Sentence Transformers en Hugging Face",
         "url": "https://huggingface.co/docs/hub/sentence-transformers",
         "type": "article"
       }
     ]
   },
   "dLEg4IA3F5jgc44Bst9if": {
-    "title": "Models on Hugging Face",
+    "title": "Modelos en Hugging Face",
     "description": "",
     "links": []
   },
   "tt9u3oFlsjEMfPyojuqpc": {
-    "title": "Vector Databases",
-    "description": "Vector databases are systems specialized in storing, indexing, and retrieving high-dimensional vectors, often used as embeddings for data like text, images, or audio. Unlike traditional databases, they excel at managing unstructured data by enabling fast similarity searches, where vectors are compared to find the closest matches. This makes them essential for tasks like semantic search, recommendation systems, and content discovery. Using techniques like approximate nearest neighbor (ANN) search, vector databases handle large datasets efficiently, ensuring quick and accurate retrieval even at scale.\n\nLearn more from the following resources:",
+    "title": "Bases de Datos Vectoriales",
+    "description": "Las bases de datos vectoriales son sistemas especializados en almacenar, indexar y recuperar vectores de alta dimensión, a menudo utilizados como embeddings para datos como texto, imágenes o audio. A diferencia de las bases de datos tradicionales, sobresalen en la gestión de datos no estructurados al permitir búsquedas rápidas de similitud, donde los vectores se comparan para encontrar las coincidencias más cercanas. Esto las hace esenciales para tareas como la búsqueda semántica, los sistemas de recomendación y el descubrimiento de contenido. Utilizando técnicas como la búsqueda aproximada del vecino más cercano (ANN), las bases de datos vectoriales manejan grandes conjuntos de datos de manera eficiente, asegurando una recuperación rápida y precisa incluso a escala.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
-        "title": "Vector Databases",
+        "title": "Bases de Datos Vectoriales",
         "url": "https://developers.cloudflare.com/vectorize/reference/what-is-a-vector-database/",
         "type": "article"
       },
       {
-        "title": "What are Vector Databases?",
+        "title": "¿Qué son las Bases de Datos Vectoriales?",
         "url": "https://www.mongodb.com/resources/basics/databases/vector-databases",
         "type": "article"
       }
     ]
   },
   "WcjX6p-V-Rdd77EL8Ega9": {
-    "title": "Purpose and Functionality",
-    "description": "A vector database is designed to store, manage, and retrieve high-dimensional vectors (embeddings) generated by AI models. Its primary purpose is to perform fast and efficient similarity searches, enabling applications to find data points that are semantically or visually similar to a given query. Unlike traditional databases, which handle structured data, vector databases excel at managing unstructured data like text, images, and audio by converting them into dense vector representations. They use indexing techniques, such as approximate nearest neighbor (ANN) algorithms, to quickly search large datasets and return relevant results. Vector databases are essential for applications like recommendation systems, semantic search, and content discovery, where understanding and retrieving similar items is crucial.\n\nLearn more from the following resources:",
+    "title": "Propósito y Funcionalidad",
+    "description": "Una base de datos vectorial está diseñada para almacenar, gestionar y recuperar vectores de alta dimensión (embeddings) generados por modelos de IA. Su propósito principal es realizar búsquedas de similitud rápidas y eficientes, permitiendo a las aplicaciones encontrar puntos de datos que sean semántica o visualmente similares a una consulta dada. A diferencia de las bases de datos tradicionales, que manejan datos estructurados, las bases de datos vectoriales sobresalen en la gestión de datos no estructurados como texto, imágenes y audio convirtiéndolos en representaciones vectoriales densas. Utilizan técnicas de indexación, como algoritmos de vecino más cercano aproximado (ANN), para buscar rápidamente en grandes conjuntos de datos y devolver resultados relevantes. Las bases de datos vectoriales son esenciales para aplicaciones como sistemas de recomendación, búsqueda semántica y descubrimiento de contenido, donde comprender y recuperar elementos similares es crucial.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
-        "title": "What is a Vector Database? Top 12 Use Cases",
+        "title": "¿Qué es una Base de Datos Vectorial? Los 12 Casos de Uso Principales",
         "url": "https://lakefs.io/blog/what-is-vector-databases/",
         "type": "article"
       },
       {
-        "title": "Vector Databases: Intro, Use Cases",
+        "title": "Bases de Datos Vectoriales: Introducción, Casos de Uso",
         "url": "https://www.v7labs.com/blog/vector-databases",
         "type": "article"
       }
@@ -1145,7 +1145,7 @@
   },
   "dSd2C9lNl-ymmCRT9_ZC3": {
     "title": "Chroma",
-    "description": "Chroma is an open-source vector database and AI-native embedding database designed to handle and store large-scale embeddings and semantic vectors. It is used in applications that require fast, efficient similarity searches, such as natural language processing (NLP), machine learning (ML), and AI systems dealing with text, images, and other high-dimensional data.\n\nVisit the following resources to learn more:",
+    "description": "Chroma es una base de datos vectorial de código abierto y una base de datos de embeddings nativa de IA diseñada para manejar y almacenar embeddings a gran escala y vectores semánticos. Se utiliza en aplicaciones que requieren búsquedas de similitud rápidas y eficientes, como el procesamiento del lenguaje natural (NLP), el aprendizaje automático (ML) y los sistemas de IA que manejan texto, imágenes y otros datos de alta dimensión.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
         "title": "Chroma",
@@ -1153,12 +1153,12 @@
         "type": "article"
       },
       {
-        "title": "Chroma Tutorials",
+        "title": "Tutoriales de Chroma",
         "url": "https://lablab.ai/tech/chroma",
         "type": "article"
       },
       {
-        "title": "Chroma - Chroma - Vector Database for LLM Applications",
+        "title": "Chroma - Chroma - Base de Datos Vectorial para Aplicaciones LLM",
         "url": "https://youtu.be/Qs_y0lTJAp0?si=Z2-eSmhf6PKrEKCW",
         "type": "video"
       }
@@ -1166,7 +1166,7 @@
   },
   "_Cf7S1DCvX7p1_3-tP3C3": {
     "title": "Pinecone",
-    "description": "Pinecone is a managed vector database designed for efficient similarity search and real-time retrieval of high-dimensional data, such as embeddings. It allows developers to store, index, and query vector representations, making it easy to build applications like recommendation systems, semantic search, and AI-driven content discovery. Pinecone is scalable, handles large datasets, and provides fast, low-latency searches using optimized indexing techniques.\n\nLearn more from the following resources:",
+    "description": "Pinecone es una base de datos vectorial gestionada diseñada para la búsqueda eficiente de similitudes y la recuperación en tiempo real de datos de alta dimensión, como los embeddings. Permite a los desarrolladores almacenar, indexar y consultar representaciones vectoriales, lo que facilita la creación de aplicaciones como sistemas de recomendación, búsqueda semántica y descubrimiento de contenido impulsado por IA. Pinecone es escalable, maneja grandes conjuntos de datos y proporciona búsquedas rápidas de baja latencia utilizando técnicas de indexación optimizadas.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
         "title": "Pinecone",
@@ -1174,12 +1174,12 @@
         "type": "article"
       },
       {
-        "title": "Everything you need to know about Pinecone",
+        "title": "Todo lo que necesitas saber sobre Pinecone",
         "url": "https://www.packtpub.com/article-hub/everything-you-need-to-know-about-pinecone-a-vector-database?srsltid=AfmBOorXsy9WImpULoLjd-42ERvTzj3pQb7C2EFgamWlRobyGJVZKKdz",
         "type": "article"
       },
       {
-        "title": "Introducing Pinecone Serverless",
+        "title": "Presentamos Pinecone Sin Servidor",
         "url": "https://www.youtube.com/watch?v=iCuR6ihHQgc",
         "type": "video"
       }
@@ -1187,7 +1187,7 @@
   },
   "VgUnrZGKVjAAO4n_llq5-": {
     "title": "Weaviate",
-    "description": "Weaviate is an open-source vector database that allows users to store, search, and manage high-dimensional vectors, often used for tasks like semantic search and recommendation systems. It enables efficient similarity searches by converting data (like text, images, or audio) into embeddings and indexing them for fast retrieval. Weaviate also supports integrating external data sources and schemas, making it easy to combine structured and unstructured data.\n\nLearn more from the following resources:",
+    "description": "Weaviate es una base de datos vectorial de código abierto que permite a los usuarios almacenar, buscar y gestionar vectores de alta dimensión, a menudo utilizados para tareas como la búsqueda semántica y los sistemas de recomendación. Permite búsquedas de similitud eficientes convirtiendo datos (como texto, imágenes o audio) en embeddings e indexándolos para una rápida recuperación. Weaviate también admite la integración de fuentes de datos y esquemas externos, lo que facilita la combinación de datos estructurados y no estructurados.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
         "title": "Weaviate",
@@ -1195,7 +1195,7 @@
         "type": "article"
       },
       {
-        "title": "Advanced AI Agents with RAG",
+        "title": "Agentes de IA Avanzados con RAG",
         "url": "https://www.youtube.com/watch?v=UoowC-hsaf0&list=PLTL2JUbrY6tVmVxY12e6vRDmY-maAXzR1",
         "type": "video"
       }
@@ -1203,7 +1203,7 @@
   },
   "JurLbOO1Z8r6C3yUqRNwf": {
     "title": "FAISS",
-    "description": "FAISS (Facebook AI Similarity Search) is a library developed by Facebook AI for efficient similarity search and clustering of dense vectors, particularly useful for large-scale datasets. It is optimized to handle embeddings (vector representations) and enables fast nearest neighbor search, allowing you to retrieve similar items from a large collection of vectors based on distance or similarity metrics like cosine similarity or Euclidean distance. FAISS is widely used in applications such as image and text retrieval, recommendation systems, and large-scale search systems where embeddings are used to represent items. It offers several indexing methods and can scale to billions of vectors, making it a powerful tool for handling real-time, large-scale similarity search problems efficiently.\n\nLearn more from the following resources:",
+    "description": "FAISS (Facebook AI Similarity Search) es una biblioteca desarrollada por Facebook AI para la búsqueda eficiente de similitudes y la agrupación de vectores densos, particularmente útil para conjuntos de datos a gran escala. Está optimizada para manejar embeddings (representaciones vectoriales) y permite una búsqueda rápida del vecino más cercano, lo que te permite recuperar elementos similares de una gran colección de vectores basados en métricas de distancia o similitud como la similitud del coseno o la distancia euclidiana. FAISS se utiliza ampliamente en aplicaciones como la recuperación de imágenes y texto, los sistemas de recomendación y los sistemas de búsqueda a gran escala donde se utilizan embeddings para representar elementos. Ofrece varios métodos de indexación y puede escalar a miles de millones de vectores, lo que la convierte en una herramienta poderosa para manejar problemas de búsqueda de similitudes a gran escala en tiempo real de manera eficiente.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
         "title": "FAISS",
@@ -1211,12 +1211,12 @@
         "type": "article"
       },
       {
-        "title": "What Is Faiss (Facebook AI Similarity Search)?",
+        "title": "¿Qué es Faiss (Facebook AI Similarity Search)?",
         "url": "https://www.datacamp.com/blog/faiss-facebook-ai-similarity-search",
         "type": "article"
       },
       {
-        "title": "FAISS Vector Library with LangChain and OpenAI",
+        "title": "Biblioteca Vectorial FAISS con LangChain y OpenAI",
         "url": "https://www.youtube.com/watch?v=ZCSsIkyCZk4",
         "type": "video"
       }
@@ -1224,10 +1224,10 @@
   },
   "rjaCNT3Li45kwu2gXckke": {
     "title": "LanceDB",
-    "description": "LanceDB is a vector database designed for efficient storage, retrieval, and management of embeddings. It enables users to perform fast similarity searches, particularly useful in applications like recommendation systems, semantic search, and AI-driven content retrieval. LanceDB focuses on scalability and speed, allowing large-scale datasets of embeddings to be indexed and queried quickly, which is essential for real-time AI applications. It integrates well with machine learning workflows, making it easier to deploy models that rely on vector-based data processing, and helps manage the complexities of handling high-dimensional vector data efficiently.\n\nLearn more from the following resources:",
+    "description": "LanceDB es una base de datos vectorial diseñada para el almacenamiento, recuperación y gestión eficiente de embeddings. Permite a los usuarios realizar búsquedas rápidas de similitud, particularmente útiles en aplicaciones como sistemas de recomendación, búsqueda semántica y recuperación de contenido impulsada por IA. LanceDB se enfoca en la escalabilidad y la velocidad, lo que permite indexar y consultar rápidamente conjuntos de datos de embeddings a gran escala, lo cual es esencial para las aplicaciones de IA en tiempo real. Se integra bien con los flujos de trabajo de aprendizaje automático, lo que facilita la implementación de modelos que dependen del procesamiento de datos basado en vectores y ayuda a gestionar las complejidades del manejo eficiente de datos vectoriales de alta dimensión.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
-        "title": "LanceDB on GitHub",
+        "title": "LanceDB en GitHub",
         "url": "https://github.com/lancedb/lancedb",
         "type": "opensource"
       },
@@ -1237,7 +1237,7 @@
         "type": "article"
       },
       {
-        "title": "LanceDB Documentation",
+        "title": "Documentación de LanceDB",
         "url": "https://docs.lancedb.com/enterprise/introduction",
         "type": "article"
       }
@@ -1245,10 +1245,10 @@
   },
   "DwOAL5mOBgBiw-EQpAzQl": {
     "title": "Qdrant",
-    "description": "Qdrant is an open-source vector database designed for efficient similarity search and real-time data retrieval. It specializes in storing and indexing high-dimensional vectors (embeddings) to enable fast and accurate searches across large datasets. Qdrant is particularly suited for applications like recommendation systems, semantic search, and AI-driven content discovery, where finding similar items quickly is essential. It supports advanced filtering, scalable indexing, and real-time updates, making it easy to integrate into machine learning workflows.\n\nLearn more from the following resources:",
+    "description": "Qdrant es una base de datos vectorial de código abierto diseñada para la búsqueda eficiente de similitudes y la recuperación de datos en tiempo real. Se especializa en almacenar e indexar vectores de alta dimensión (embeddings) para permitir búsquedas rápidas y precisas en grandes conjuntos de datos. Qdrant es particularmente adecuada para aplicaciones como sistemas de recomendación, búsqueda semántica y descubrimiento de contenido impulsado por IA, donde encontrar elementos similares rápidamente es esencial. Admite filtrado avanzado, indexación escalable y actualizaciones en tiempo real, lo que facilita su integración en los flujos de trabajo de aprendizaje automático.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
-        "title": "Qdrant on GitHub",
+        "title": "Qdrant en GitHub",
         "url": "https://github.com/qdrant/qdrant",
         "type": "opensource"
       },
@@ -1258,7 +1258,7 @@
         "type": "article"
       },
       {
-        "title": "Getting started with Qdrant",
+        "title": "Primeros pasos con Qdrant",
         "url": "https://www.youtube.com/watch?v=LRcZ9pbGnno",
         "type": "video"
       }
@@ -1266,7 +1266,7 @@
   },
   "9kT7EEQsbeD2WDdN9ADx7": {
     "title": "Supabase",
-    "description": "Supabase Vector is an extension of the Supabase platform, specifically designed for AI and machine learning applications that require vector operations. It leverages PostgreSQL's pgvector extension to provide efficient vector storage and similarity search capabilities. This makes Supabase Vector particularly useful for applications involving embeddings, semantic search, and recommendation systems. With Supabase Vector, developers can store and query high-dimensional vector data alongside regular relational data, all within the same PostgreSQL database.\n\nLearn more from the following resources:",
+    "description": "Supabase Vector es una extensión de la plataforma Supabase, diseñada específicamente para aplicaciones de IA y aprendizaje automático que requieren operaciones vectoriales. Aprovecha la extensión pgvector de PostgreSQL para proporcionar capacidades eficientes de almacenamiento de vectores y búsqueda de similitudes. Esto hace que Supabase Vector sea particularmente útil para aplicaciones que involucran embeddings, búsqueda semántica y sistemas de recomendación. Con Supabase Vector, los desarrolladores pueden almacenar y consultar datos vectoriales de alta dimensión junto con datos relacionales regulares, todo dentro de la misma base de datos PostgreSQL.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
         "title": "Supabase Vector",
@@ -1274,7 +1274,7 @@
         "type": "article"
       },
       {
-        "title": "Supabase Vector: The Postgres Vector database",
+        "title": "Supabase Vector: La base de datos vectorial de Postgres",
         "url": "https://www.youtube.com/watch?v=MDxEXKkxf2Q",
         "type": "video"
       }
@@ -1282,116 +1282,116 @@
   },
   "j6bkm0VUgLkHdMDDJFiMC": {
     "title": "MongoDB Atlas",
-    "description": "MongoDB Atlas, traditionally known for its document database capabilities, now includes vector search functionality, making it a strong option as a vector database. This feature allows developers to store and query high-dimensional vector data alongside regular document data. With Atlas’s vector search, users can perform similarity searches on embeddings of text, images, or other complex data, making it ideal for AI and machine learning applications like recommendation systems, image similarity search, and natural language processing tasks. The seamless integration of vector search within the MongoDB ecosystem allows developers to leverage familiar tools and interfaces while benefiting from advanced vector-based operations for sophisticated data analysis and retrieval.\n\nLearn more from the following resources:",
+    "description": "MongoDB Atlas, tradicionalmente conocido por sus capacidades de base de datos de documentos, ahora incluye la funcionalidad de búsqueda vectorial, lo que lo convierte en una opción sólida como base de datos vectorial. Esta característica permite a los desarrolladores almacenar y consultar datos vectoriales de alta dimensión junto con datos de documentos regulares. Con la búsqueda vectorial de Atlas, los usuarios pueden realizar búsquedas de similitud en embeddings de texto, imágenes u otros datos complejos, lo que lo hace ideal para aplicaciones de IA y aprendizaje automático como sistemas de recomendación, búsqueda de similitud de imágenes y tareas de procesamiento del lenguaje natural. La perfecta integración de la búsqueda vectorial dentro del ecosistema de MongoDB permite a los desarrolladores aprovechar herramientas e interfaces familiares mientras se benefician de operaciones avanzadas basadas en vectores para un análisis y recuperación de datos sofisticados.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
-        "title": "Vector Search in MongoDB Atlas",
+        "title": "Búsqueda Vectorial en MongoDB Atlas",
         "url": "https://www.mongodb.com/products/platform/atlas-vector-search",
         "type": "article"
       }
     ]
   },
   "5TQnO9B4_LTHwqjI7iHB1": {
-    "title": "Indexing Embeddings",
-    "description": "Embeddings are stored in a vector database by first converting data, such as text, images, or audio, into high-dimensional vectors using machine learning models. These vectors, also called embeddings, capture the semantic relationships and patterns within the data. Once generated, each embedding is indexed in the vector database along with its associated metadata, such as the original data (e.g., text or image) or an identifier. The vector database then organizes these embeddings to support efficient similarity searches, typically using techniques like approximate nearest neighbor (ANN) search.\n\nLearn more from the following resources:",
+    "title": "Indexación de Embeddings",
+    "description": "Los embeddings se almacenan en una base de datos vectorial convirtiendo primero los datos, como texto, imágenes o audio, en vectores de alta dimensión utilizando modelos de aprendizaje automático. Estos vectores, también llamados embeddings, capturan las relaciones semánticas y los patrones dentro de los datos. Una vez generado, cada embedding se indexa en la base de datos vectorial junto con sus metadatos asociados, como los datos originales (por ejemplo, texto o imagen) o un identificador. Luego, la base de datos vectorial organiza estos embeddings para admitir búsquedas de similitud eficientes, generalmente utilizando técnicas como la búsqueda aproximada del vecino más cercano (ANN).\n\nAprende más de los siguientes recursos:",
     "links": [
       {
-        "title": "Indexing & Embeddings",
+        "title": "Indexación y Embeddings",
         "url": "https://docs.llamaindex.ai/en/stable/understanding/indexing/indexing/",
         "type": "article"
       },
       {
-        "title": "Vector Databases Simply Explained! (Embeddings & Indexes)",
+        "title": "¡Bases de Datos Vectoriales Explicadas de Forma Sencilla! (Embeddings e Índices)",
         "url": "https://www.youtube.com/watch?v=dN0lsF2cvm4",
         "type": "video"
       }
     ]
   },
   "ZcbRPtgaptqKqWBgRrEBU": {
-    "title": "Performing Similarity Search",
-    "description": "In a similarity search, the process begins by converting the user’s query (such as a piece of text or an image) into an embedding—a vector representation that captures the query’s semantic meaning. This embedding is generated using a pre-trained model, such as BERT for text or a neural network for images. Once the query is converted into a vector, it is compared to the embeddings stored in the vector database.\n\nVisit the following resources to learn more:",
+    "title": "Realización de Búsqueda por Similitud",
+    "description": "En una búsqueda por similitud, el proceso comienza convirtiendo la consulta del usuario (como un fragmento de texto o una imagen) en un embedding, una representación vectorial que captura el significado semántico de la consulta. Este embedding se genera utilizando un modelo preentrenado, como BERT para texto o una red neuronal para imágenes. Una vez que la consulta se convierte en un vector, se compara con los embeddings almacenados en la base de datos vectorial.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "What is Similarity Search & How Does it work?",
+        "title": "¿Qué es la Búsqueda por Similitud y Cómo Funciona?",
         "url": "https://www.truefoundry.com/blog/similarity-search",
         "type": "article"
       }
     ]
   },
   "lVhWhZGR558O-ljHobxIi": {
-    "title": "RAG & Implementation",
-    "description": "Retrieval-Augmented Generation (RAG) combines information retrieval with language generation to produce more accurate, context-aware responses. It uses two components: a retriever, which searches a database to find relevant information, and a generator, which crafts a response based on the retrieved data. Implementing RAG involves using a retrieval model (e.g., embeddings and vector search) alongside a generative language model (like GPT). The process starts by converting a query into embeddings, retrieving relevant documents from a vector database, and feeding them to the language model, which then generates a coherent, informed response. This approach grounds outputs in real-world data, resulting in more reliable and detailed answers.\n\nLearn more from the following resources:",
+    "title": "RAG e Implementación",
+    "description": "La Generación Aumentada por Recuperación (RAG) combina la recuperación de información con la generación de lenguaje para producir respuestas más precisas y conscientes del contexto. Utiliza dos componentes: un recuperador, que busca en una base de datos para encontrar información relevante, y un generador, que elabora una respuesta basada en los datos recuperados. La implementación de RAG implica el uso de un modelo de recuperación (por ejemplo, embeddings y búsqueda vectorial) junto con un modelo de lenguaje generativo (como GPT). El proceso comienza convirtiendo una consulta en embeddings, recuperando documentos relevantes de una base de datos vectorial y alimentándolos al modelo de lenguaje, que luego genera una respuesta coherente e informada. Este enfoque basa las salidas en datos del mundo real, lo que da como resultado respuestas más confiables y detalladas.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
-        "title": "What is RAG?",
+        "title": "¿Qué es RAG?",
         "url": "https://aws.amazon.com/what-is/retrieval-augmented-generation/",
         "type": "article"
       },
       {
-        "title": "What is Retrieval-Augmented Generation? IBM",
+        "title": "¿Qué es la Generación Aumentada por Recuperación? IBM",
         "url": "https://www.youtube.com/watch?v=T-D1OfcDW1M",
         "type": "video"
       }
     ]
   },
   "GCn4LGNEtPI0NWYAZCRE-": {
-    "title": "RAG Usecases",
-    "description": "Retrieval-Augmented Generation (RAG) enhances applications like chatbots, customer support, and content summarization by combining information retrieval with language generation. It retrieves relevant data from a knowledge base and uses it to generate accurate, context-aware responses, making it ideal for tasks such as question answering, document generation, and semantic search. RAG’s ability to ground outputs in real-world information leads to more reliable and informative results, improving user experience across various domains.\n\nLearn more from the following resources:",
+    "title": "Casos de Uso de RAG",
+    "description": "La Generación Aumentada por Recuperación (RAG) mejora aplicaciones como chatbots, soporte al cliente y resumen de contenido al combinar la recuperación de información con la generación de lenguaje. Recupera datos relevantes de una base de conocimientos y los utiliza para generar respuestas precisas y conscientes del contexto, lo que la hace ideal para tareas como respuesta a preguntas, generación de documentos y búsqueda semántica. La capacidad de RAG para basar los resultados en información del mundo real conduce a resultados más confiables e informativos, mejorando la experiencia del usuario en diversos dominios.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
-        "title": "Retrieval augmented generation use cases: Transforming data into insights",
+        "title": "Casos de uso de generación aumentada por recuperación: Transformando datos en información",
         "url": "https://www.glean.com/blog/retrieval-augmented-generation-use-cases",
         "type": "article"
       },
       {
-        "title": "Retrieval Augmented Generation (RAG) – 5 Use Cases",
+        "title": "Generación Aumentada por Recuperación (RAG) – 5 Casos de Uso",
         "url": "https://theblue.ai/blog/rag-news/",
         "type": "article"
       },
       {
-        "title": "Introduction to RAG",
+        "title": "Introducción a RAG",
         "url": "https://www.youtube.com/watch?v=LmiFeXH-kq8&list=PL-pTHQz4RcBbz78Z5QXsZhe9rHuCs1Jw-",
         "type": "video"
       }
     ]
   },
   "qlBEXrbV88e_wAGRwO9hW": {
-    "title": "RAG vs Fine-tuning",
-    "description": "RAG (Retrieval-Augmented Generation) and fine-tuning are two approaches to enhancing language models, but they differ in methodology and use cases. Fine-tuning involves training a pre-trained model on a specific dataset to adapt it to a particular task, making it more accurate for that context but limited to the knowledge present in the training data. RAG, on the other hand, combines real-time information retrieval with generation, enabling the model to access up-to-date external data and produce contextually relevant responses. While fine-tuning is ideal for specialized, static tasks, RAG is better suited for dynamic tasks that require real-time, fact-based responses.\n\nLearn more from the following resources:",
+    "title": "RAG vs Ajuste Fino",
+    "description": "RAG (Generación Aumentada por Recuperación) y el ajuste fino son dos enfoques para mejorar los modelos de lenguaje, pero difieren en metodología y casos de uso. El ajuste fino implica entrenar un modelo preentrenado en un conjunto de datos específico para adaptarlo a una tarea particular, haciéndolo más preciso para ese contexto pero limitado al conocimiento presente en los datos de entrenamiento. RAG, por otro lado, combina la recuperación de información en tiempo real con la generación, lo que permite al modelo acceder a datos externos actualizados y producir respuestas contextualmente relevantes. Si bien el ajuste fino es ideal para tareas especializadas y estáticas, RAG es más adecuado para tareas dinámicas que requieren respuestas basadas en hechos en tiempo real.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
-        "title": "RAG vs Fine Tuning: How to Choose the Right Method",
+        "title": "RAG vs Ajuste Fino: Cómo Elegir el Método Correcto",
         "url": "https://www.montecarlodata.com/blog-rag-vs-fine-tuning/",
         "type": "article"
       },
       {
-        "title": "RAG vs Finetuning — Which Is the Best Tool to Boost Your LLM Application?",
+        "title": "RAG vs Ajuste Fino — ¿Cuál es la Mejor Herramienta para Impulsar tu Aplicación LLM?",
         "url": "https://towardsdatascience.com/rag-vs-finetuning-which-is-the-best-tool-to-boost-your-llm-application-94654b1eaba7",
         "type": "article"
       },
       {
-        "title": "RAG vs Fine-tuning",
+        "title": "RAG vs Ajuste Fino",
         "url": "https://www.youtube.com/watch?v=00Q0G84kq3M",
         "type": "video"
       }
     ]
   },
   "mX987wiZF7p3V_gExrPeX": {
-    "title": "Chunking",
-    "description": "The chunking step in Retrieval-Augmented Generation (RAG) involves breaking down large documents or data sources into smaller, manageable chunks. This is done to ensure that the retriever can efficiently search through large volumes of data while staying within the token or input limits of the model. Each chunk, typically a paragraph or section, is converted into an embedding, and these embeddings are stored in a vector database. When a query is made, the retriever searches for the most relevant chunks rather than the entire document, enabling faster and more accurate retrieval.\n\nLearn more from the following resources:",
+    "title": "Fragmentación (Chunking)",
+    "description": "El paso de fragmentación en la Generación Aumentada por Recuperación (RAG) implica dividir documentos grandes o fuentes de datos en fragmentos más pequeños y manejables. Esto se hace para garantizar que el recuperador pueda buscar eficientemente a través de grandes volúmenes de datos mientras se mantiene dentro de los límites de tokens o de entrada del modelo. Cada fragmento, generalmente un párrafo o sección, se convierte en un embedding, y estos embeddings se almacenan en una base de datos vectorial. Cuando se realiza una consulta, el recuperador busca los fragmentos más relevantes en lugar del documento completo, lo que permite una recuperación más rápida y precisa.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
-        "title": "Understanding LangChain's RecursiveCharacterTextSplitter",
+        "title": "Comprendiendo el RecursiveCharacterTextSplitter de LangChain",
         "url": "https://dev.to/eteimz/understanding-langchains-recursivecharactertextsplitter-2846",
         "type": "article"
       },
       {
-        "title": "Chunking Strategies for LLM Applications",
+        "title": "Estrategias de Fragmentación para Aplicaciones LLM",
         "url": "https://www.pinecone.io/learn/chunking-strategies/",
         "type": "article"
       },
       {
-        "title": "A Guide to Chunking Strategies for Retrieval Augmented Generation",
+        "title": "Una Guía de Estrategias de Fragmentación para la Generación Aumentada por Recuperación",
         "url": "https://zilliz.com/learn/guide-to-chunking-strategies-for-rag",
         "type": "article"
       }
@@ -1399,84 +1399,84 @@
   },
   "grTcbzT7jKk_sIUwOTZTD": {
     "title": "Embedding",
-    "description": "In Retrieval-Augmented Generation (RAG), embeddings are essential for linking information retrieval with natural language generation. Embeddings represent both the user query and documents as dense vectors in a shared space, enabling the system to retrieve relevant information based on similarity. This retrieved information is then fed into a generative model, such as GPT, to produce contextually informed and accurate responses. By using embeddings, RAG enhances the model's ability to generate content grounded in external knowledge, making it effective for tasks like question answering and summarization.\n\nLearn more from the following resources:",
+    "description": "En la Generación Aumentada por Recuperación (RAG), los embeddings son esenciales para vincular la recuperación de información con la generación de lenguaje natural. Los embeddings representan tanto la consulta del usuario como los documentos como vectores densos en un espacio compartido, lo que permite al sistema recuperar información relevante basada en la similitud. Esta información recuperada se introduce luego en un modelo generativo, como GPT, para producir respuestas precisas e informadas contextualmente. Al usar embeddings, RAG mejora la capacidad del modelo para generar contenido basado en conocimiento externo, lo que lo hace efectivo para tareas como respuesta a preguntas y resumen.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
-        "title": "Understanding the role of embeddings in RAG LLMs",
+        "title": "Comprendiendo el papel de los embeddings en los LLM de RAG",
         "url": "https://www.aporia.com/learn/understanding-the-role-of-embeddings-in-rag-llms/",
         "type": "article"
       },
       {
-        "title": "Mastering RAG: How to Select an Embedding Model",
+        "title": "Dominando RAG: Cómo Seleccionar un Modelo de Embedding",
         "url": "https://www.rungalileo.io/blog/mastering-rag-how-to-select-an-embedding-model",
         "type": "article"
       }
     ]
   },
   "zZA1FBhf1y4kCoUZ-hM4H": {
-    "title": "Vector Database",
-    "description": "When implementing Retrieval-Augmented Generation (RAG), a vector database is used to store and efficiently retrieve embeddings, which are vector representations of data like documents, images, or other knowledge sources. During the RAG process, when a query is made, the system converts it into an embedding and searches the vector database for the most relevant, similar embeddings (e.g., related documents or snippets). These retrieved pieces of information are then fed to a generative model, which uses them to produce a more accurate, context-aware response.\n\nLearn more from the following resources:",
+    "title": "Base de Datos Vectorial",
+    "description": "Al implementar la Generación Aumentada por Recuperación (RAG), se utiliza una base de datos vectorial para almacenar y recuperar eficientemente embeddings, que son representaciones vectoriales de datos como documentos, imágenes u otras fuentes de conocimiento. Durante el proceso RAG, cuando se realiza una consulta, el sistema la convierte en un embedding y busca en la base de datos vectorial los embeddings más relevantes y similares (por ejemplo, documentos o fragmentos relacionados). Estas piezas de información recuperadas se introducen luego en un modelo generativo, que las utiliza para producir una respuesta más precisa y consciente del contexto.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
-        "title": "How to Implement Graph RAG Using Knowledge Graphs and Vector Databases",
+        "title": "Cómo Implementar Graph RAG Usando Grafos de Conocimiento y Bases de Datos Vectoriales",
         "url": "https://towardsdatascience.com/how-to-implement-graph-rag-using-knowledge-graphs-and-vector-databases-60bb69a22759",
         "type": "article"
       },
       {
-        "title": "Retrieval Augmented Generation (RAG) with Vector Databases: Expanding AI Capabilities",
+        "title": "Generación Aumentada por Recuperación (RAG) con Bases de Datos Vectoriales: Expandiendo las Capacidades de la IA",
         "url": "https://objectbox.io/retrieval-augmented-generation-rag-with-vector-databases-expanding-ai-capabilities/",
         "type": "article"
       }
     ]
   },
   "OCGCzHQM2LQyUWmiqe6E0": {
-    "title": "Retrieval Process",
-    "description": "The retrieval process in Retrieval-Augmented Generation (RAG) involves finding relevant information from a large dataset or knowledge base to support the generation of accurate, context-aware responses. When a query is received, the system first converts it into a vector (embedding) and uses this vector to search a database of pre-indexed embeddings, identifying the most similar or relevant data points. Techniques like approximate nearest neighbor (ANN) search are often used to speed up this process.\n\nLearn more from the following resources:",
+    "title": "Proceso de Recuperación",
+    "description": "El proceso de recuperación en la Generación Aumentada por Recuperación (RAG) implica encontrar información relevante de un gran conjunto de datos o base de conocimientos para respaldar la generación de respuestas precisas y conscientes del contexto. Cuando se recibe una consulta, el sistema primero la convierte en un vector (embedding) y utiliza este vector para buscar en una base de datos de embeddings preindexados, identificando los puntos de datos más similares o relevantes. A menudo se utilizan técnicas como la búsqueda aproximada del vecino más cercano (ANN) para acelerar este proceso.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
-        "title": "What is Retrieval-Augmented Generation (RAG)?",
+        "title": "¿Qué es la Generación Aumentada por Recuperación (RAG)?",
         "url": "https://cloud.google.com/use-cases/retrieval-augmented-generation",
         "type": "article"
       },
       {
-        "title": "What Is Retrieval-Augmented Generation, aka RAG?",
+        "title": "¿Qué es la Generación Aumentada por Recuperación, también conocida como RAG?",
         "url": "https://blogs.nvidia.com/blog/what-is-retrieval-augmented-generation/",
         "type": "article"
       }
     ]
   },
   "2jJnS9vRYhaS69d6OxrMh": {
-    "title": "Generation",
-    "description": "Generation refers to the process where a generative language model, such as GPT, creates a response based on the information retrieved during the retrieval phase. After relevant documents or data snippets are identified using embeddings, they are passed to the generative model, which uses this information to produce coherent, context-aware, and informative responses. The retrieved content helps the model stay grounded and factual, enhancing its ability to answer questions, provide summaries, or engage in dialogue by combining retrieved knowledge with its natural language generation capabilities. This synergy between retrieval and generation makes RAG systems effective for tasks that require detailed, accurate, and contextually relevant outputs.\n\nLearn more from the following resources:",
+    "title": "Generación",
+    "description": "La generación se refiere al proceso en el que un modelo de lenguaje generativo, como GPT, crea una respuesta basada en la información recuperada durante la fase de recuperación. Después de identificar documentos o fragmentos de datos relevantes mediante embeddings, estos se pasan al modelo generativo, que utiliza esta información para producir respuestas coherentes, conscientes del contexto e informativas. El contenido recuperado ayuda al modelo a mantenerse fundamentado y fáctico, mejorando su capacidad para responder preguntas, proporcionar resúmenes o participar en diálogos combinando el conocimiento recuperado con sus capacidades de generación de lenguaje natural. Esta sinergia entre la recuperación y la generación hace que los sistemas RAG sean efectivos para tareas que requieren resultados detallados, precisos y contextualmente relevantes.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
-        "title": "What is RAG (Retrieval-Augmented Generation)?",
+        "title": "¿Qué es RAG (Generación Aumentada por Recuperación)?",
         "url": "https://aws.amazon.com/what-is/retrieval-augmented-generation/",
         "type": "article"
       },
       {
-        "title": "Retrieval Augmented Generation (RAG) Explained in 8 Minutes!",
+        "title": "¡Generación Aumentada por Recuperación (RAG) Explicada en 8 Minutos!",
         "url": "https://www.youtube.com/watch?v=HREbdmOSQ18",
         "type": "video"
       }
     ]
   },
   "WZVW8FQu6LyspSKm1C_sl": {
-    "title": "Using SDKs Directly",
-    "description": "While tools like Langchain and LlamaIndex make it easy to implement RAG, you don't have to necessarily learn and use them. If you know about the different steps of implementing RAG you can simply do it all yourself e.g. do the chunking using `@langchain/textsplitters` package, create embeddings using any LLM e.g. use OpenAI Embedding API through their SDK, save the embeddings to any vector database e.g. if you are using Supabase Vector DB, you can use their SDK and similarly you can use the relevant SDKs for the rest of the steps as well.\n\nLearn more from the following resources:",
+    "title": "Uso Directo de SDKs",
+    "description": "Aunque herramientas como Langchain y LlamaIndex facilitan la implementación de RAG, no necesariamente tienes que aprenderlas y usarlas. Si conoces los diferentes pasos para implementar RAG, simplemente puedes hacerlo todo tú mismo, por ejemplo, realizar la fragmentación usando el paquete `@langchain/textsplitters`, crear embeddings usando cualquier LLM, por ejemplo, usar la API de Embedding de OpenAI a través de su SDK, guardar los embeddings en cualquier base de datos vectorial, por ejemplo, si estás usando Supabase Vector DB, puedes usar su SDK y, de manera similar, puedes usar los SDK relevantes para el resto de los pasos también.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
-        "title": "Langchain Text Splitter Package",
+        "title": "Paquete Langchain Text Splitter",
         "url": "https://www.npmjs.com/package/@langchain/textsplitters",
         "type": "article"
       },
       {
-        "title": "OpenAI Embedding API",
+        "title": "API de Embedding de OpenAI",
         "url": "https://platform.openai.com/docs/guides/embeddings",
         "type": "article"
       },
       {
-        "title": "Supabase AI & Vector Documentation",
+        "title": "Documentación de IA y Vectores de Supabase",
         "url": "https://supabase.com/docs/guides/ai",
         "type": "article"
       }
@@ -1484,7 +1484,7 @@
   },
   "ebXXEhNRROjbbof-Gym4p": {
     "title": "Langchain",
-    "description": "LangChain is a development framework that simplifies building applications powered by language models, enabling seamless integration of multiple AI models and data sources. It focuses on creating chains, or sequences, of operations where language models can interact with databases, APIs, and other models to perform complex tasks. LangChain offers tools for prompt management, data retrieval, and workflow orchestration, making it easier to develop robust, scalable applications like chatbots, automated data analysis, and multi-step reasoning systems.\n\nLearn more from the following resources:",
+    "description": "LangChain es un marco de desarrollo que simplifica la creación de aplicaciones impulsadas por modelos de lenguaje, lo que permite la integración perfecta de múltiples modelos de IA y fuentes de datos. Se centra en la creación de cadenas, o secuencias, de operaciones donde los modelos de lenguaje pueden interactuar con bases de datos, API y otros modelos para realizar tareas complejas. LangChain ofrece herramientas para la gestión de prompts, la recuperación de datos y la orquestación de flujos de trabajo, lo que facilita el desarrollo de aplicaciones robustas y escalables como chatbots, análisis de datos automatizado y sistemas de razonamiento de varios pasos.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
         "title": "LangChain",
@@ -1492,7 +1492,7 @@
         "type": "article"
       },
       {
-        "title": "What is LangChain?",
+        "title": "¿Qué es LangChain?",
         "url": "https://www.youtube.com/watch?v=1bUy-1hGZpI",
         "type": "video"
       }
@@ -1500,7 +1500,7 @@
   },
   "d0ontCII8KI8wfP-8Y45R": {
     "title": "Llama Index",
-    "description": "LlamaIndex, formerly known as GPT Index, is a tool designed to facilitate the integration of large language models (LLMs) with structured and unstructured data sources. It acts as a data framework that helps developers build retrieval-augmented generation (RAG) applications by indexing various types of data, such as documents, databases, and APIs, enabling LLMs to query and retrieve relevant information efficiently.\n\nLearn more from the following resources:",
+    "description": "LlamaIndex, anteriormente conocido como GPT Index, es una herramienta diseñada para facilitar la integración de modelos de lenguaje grandes (LLM) con fuentes de datos estructuradas y no estructuradas. Actúa como un marco de datos que ayuda a los desarrolladores a crear aplicaciones de generación aumentada por recuperación (RAG) indexando varios tipos de datos, como documentos, bases de datos y API, lo que permite a los LLM consultar y recuperar información relevante de manera eficiente.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
         "title": "Llama Index",
@@ -1508,23 +1508,23 @@
         "type": "article"
       },
       {
-        "title": "Introduction to LlamaIndex with Python (2024)",
+        "title": "Introducción a LlamaIndex con Python (2024)",
         "url": "https://www.youtube.com/watch?v=cCyYGYyCka4",
         "type": "video"
       }
     ]
   },
   "eOqCBgBTKM8CmY3nsWjre": {
-    "title": "Open AI Assistant API",
-    "description": "The OpenAI Assistant API enables developers to create advanced conversational systems using models like GPT-4. It supports multi-turn conversations, allowing the AI to maintain context across exchanges, which is ideal for chatbots, virtual assistants, and interactive applications. Developers can customize interactions by defining roles, such as system, user, and assistant, to guide the assistant's behavior. With features like temperature control, token limits, and stop sequences, the API offers flexibility to ensure responses are relevant, safe, and tailored to specific use cases.\n\nLearn more from the following resources:",
+    "title": "API de Asistente de OpenAI",
+    "description": "La API de Asistentes de OpenAI permite a los desarrolladores crear sistemas conversacionales avanzados utilizando modelos como GPT-4. Admite conversaciones de varios turnos, lo que permite a la IA mantener el contexto a través de los intercambios, lo cual es ideal para chatbots, asistentes virtuales y aplicaciones interactivas. Los desarrolladores pueden personalizar las interacciones definiendo roles, como sistema, usuario y asistente, para guiar el comportamiento del asistente. Con funciones como control de temperatura, límites de tokens y secuencias de parada, la API ofrece flexibilidad para garantizar que las respuestas sean relevantes, seguras y adaptadas a casos de uso específicos.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
-        "title": "OpenAI Assistants API – Course for Beginners",
+        "title": "API de Asistentes de OpenAI – Curso para Principiantes",
         "url": "https://www.youtube.com/watch?v=qHPonmSX4Ms",
         "type": "course"
       },
       {
-        "title": "Assistants API",
+        "title": "API de Asistentes",
         "url": "https://platform.openai.com/docs/assistants/overview",
         "type": "article"
       }
@@ -1532,7 +1532,7 @@
   },
   "c0RPhpD00VIUgF4HJgN2T": {
     "title": "Replicate",
-    "description": "Replicate is a platform that allows developers to run machine learning models in the cloud without needing to manage infrastructure. It provides a simple API for deploying and scaling models, making it easy to integrate AI capabilities like image generation, text processing, and more into applications. Users can select from a library of pre-trained models or deploy their own, with the platform handling tasks like scaling, monitoring, and versioning.\n\nLearn more from the following resources:",
+    "description": "Replicate es una plataforma que permite a los desarrolladores ejecutar modelos de aprendizaje automático en la nube sin necesidad de gestionar la infraestructura. Proporciona una API simple para implementar y escalar modelos, lo que facilita la integración de capacidades de IA como la generación de imágenes, el procesamiento de texto y más en las aplicaciones. Los usuarios pueden seleccionar de una biblioteca de modelos preentrenados o implementar los suyos propios, y la plataforma se encarga de tareas como el escalado, el monitoreo y el control de versiones.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
         "title": "Replicate",
@@ -1540,164 +1540,164 @@
         "type": "article"
       },
       {
-        "title": "Replicate.com Beginners Tutorial",
+        "title": "Tutorial para Principiantes de Replicate.com",
         "url": "https://www.youtube.com/watch?v=y0_GE5ErqY8",
         "type": "video"
       }
     ]
   },
   "AeHkNU-uJ_gBdo5-xdpEu": {
-    "title": "AI Agents",
-    "description": "In AI engineering, \"agents\" refer to autonomous systems or components that can perceive their environment, make decisions, and take actions to achieve specific goals. Agents often interact with external systems, users, or other agents to carry out complex tasks. They can vary in complexity, from simple rule-based bots to sophisticated AI-powered agents that leverage machine learning models, natural language processing, and reinforcement learning.\n\nVisit the following resources to learn more:",
+    "title": "Agentes de IA",
+    "description": "En la ingeniería de IA, los \"agentes\" se refieren a sistemas o componentes autónomos que pueden percibir su entorno, tomar decisiones y realizar acciones para alcanzar objetivos específicos. Los agentes a menudo interactúan con sistemas externos, usuarios u otros agentes para llevar a cabo tareas complejas. Pueden variar en complejidad, desde simples bots basados en reglas hasta sofisticados agentes impulsados por IA que aprovechan modelos de aprendizaje automático, procesamiento del lenguaje natural y aprendizaje por refuerzo.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "Building an AI Agent Tutorial - LangChain",
+        "title": "Tutorial para Construir un Agente de IA - LangChain",
         "url": "https://python.langchain.com/docs/tutorials/agents/",
         "type": "article"
       },
       {
-        "title": "AI agents and their types",
+        "title": "Agentes de IA y sus tipos",
         "url": "https://play.ht/blog/ai-agents-use-cases/",
         "type": "article"
       },
       {
-        "title": "The Complete Guide to Building AI Agents for Beginners",
+        "title": "La Guía Completa para Construir Agentes de IA para Principiantes",
         "url": "https://youtu.be/MOyl58VF2ak?si=-QjRD_5y3iViprJX",
         "type": "video"
       }
     ]
   },
   "778HsQzTuJ_3c9OSn5DmH": {
-    "title": "Agents Usecases",
-    "description": "AI Agents have a variety of usecases ranging from customer support, workflow automation, cybersecurity, finance, marketing and sales, and more.\n\nVisit the following resources to learn more:",
+    "title": "Casos de Uso de Agentes",
+    "description": "Los Agentes de IA tienen una variedad de casos de uso que van desde soporte al cliente, automatización de flujos de trabajo, ciberseguridad, finanzas, marketing y ventas, y más.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "Top 15 Use Cases Of AI Agents In Business",
+        "title": "Los 15 Casos de Uso Principales de los Agentes de IA en los Negocios",
         "url": "https://www.ampcome.com/post/15-use-cases-of-ai-agents-in-business",
         "type": "article"
       },
       {
-        "title": "A Brief Guide on AI Agents: Benefits and Use Cases",
+        "title": "Una Breve Guía sobre Agentes de IA: Beneficios y Casos de Uso",
         "url": "https://www.codica.com/blog/brief-guide-on-ai-agents/",
         "type": "article"
       },
       {
-        "title": "The Complete Guide to Building AI Agents for Beginners",
+        "title": "La Guía Completa para Construir Agentes de IA para Principiantes",
         "url": "https://youtu.be/MOyl58VF2ak?si=-QjRD_5y3iViprJX",
         "type": "video"
       }
     ]
   },
   "voDKcKvXtyLzeZdx2g3Qn": {
-    "title": "ReAct Prompting",
-    "description": "ReAct prompting is a technique that combines reasoning and action by guiding language models to think through a problem step-by-step and then take specific actions based on the reasoning. It encourages the model to break down tasks into logical steps (reasoning) and perform operations, such as calling APIs or retrieving information (actions), to reach a solution. This approach helps in scenarios where the model needs to process complex queries, interact with external systems, or handle tasks requiring a sequence of actions, improving the model's ability to provide accurate and context-aware responses.\n\nLearn more from the following resources:",
+    "title": "Prompting ReAct",
+    "description": "El prompting ReAct es una técnica que combina el razonamiento y la acción guiando a los modelos de lenguaje a pensar en un problema paso a paso y luego tomar acciones específicas basadas en el razonamiento. Anima al modelo a dividir las tareas en pasos lógicos (razonamiento) y realizar operaciones, como llamar a API o recuperar información (acciones), para llegar una solución. Este enfoque ayuda en escenarios donde el modelo necesita procesar consultas complejas, interactuar con sistemas externos o manejar tareas que requieren una secuencia de acciones, mejorando la capacidad del modelo para proporcionar respuestas precisas y conscientes del contexto.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
-        "title": "ReAct Prompting",
+        "title": "Prompting ReAct",
         "url": "https://www.promptingguide.ai/techniques/react",
         "type": "article"
       },
       {
-        "title": "ReAct Prompting: How We Prompt for High-Quality Results from LLMs",
+        "title": "Prompting ReAct: Cómo Creamos Prompts para Resultados de Alta Calidad de los LLMs",
         "url": "https://www.width.ai/post/react-prompting",
         "type": "article"
       }
     ]
   },
   "6xaRB34_g0HGt-y1dGYXR": {
-    "title": "Manual Implementation",
-    "description": "Services like Open AI functions and Tools or Vercel's AI SDK make it really easy to make SDK agents however it is a good idea to learn how these tools work under the hood. You can also create fully custom implementation of agents using by implementing custom loop.\n\nLearn more from the following resources:",
+    "title": "Implementación Manual",
+    "description": "Servicios como las funciones y herramientas de OpenAI o el SDK de IA de Vercel facilitan mucho la creación de agentes SDK; sin embargo, es una buena idea aprender cómo funcionan estas herramientas internamente. También puedes crear una implementación totalmente personalizada de agentes implementando un bucle personalizado.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
-        "title": "OpenAI Function Calling",
+        "title": "Llamada de Funciones de OpenAI",
         "url": "https://platform.openai.com/docs/guides/function-calling",
         "type": "article"
       },
       {
-        "title": "Vercel AI SDK",
+        "title": "SDK de IA de Vercel",
         "url": "https://sdk.vercel.ai/docs/foundations/tools",
         "type": "article"
       }
     ]
   },
   "Sm0Ne5Nx72hcZCdAcC0C2": {
-    "title": "OpenAI Functions / Tools",
-    "description": "OpenAI Functions, also known as tools, enable developers to extend the capabilities of language models by integrating external APIs and functionalities, allowing the models to perform specific actions, fetch real-time data, or interact with other software systems. This feature enhances the model's utility by bridging it with services like web searches, databases, and custom business applications, enabling more dynamic and task-oriented responses.\n\nLearn more from the following resources:",
+    "title": "Funciones / Herramientas de OpenAI",
+    "description": "Las Funciones de OpenAI, también conocidas como herramientas, permiten a los desarrolladores ampliar las capacidades de los modelos de lenguaje integrando API y funcionalidades externas, lo que permite a los modelos realizar acciones específicas, obtener datos en tiempo real o interactuar con otros sistemas de software. Esta característica mejora la utilidad del modelo al conectarlo con servicios como búsquedas web, bases de datos y aplicaciones comerciales personalizadas, lo que permite respuestas más dinámicas y orientadas a tareas.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
-        "title": "Function Calling",
+        "title": "Llamada de Funciones",
         "url": "https://platform.openai.com/docs/guides/function-calling",
         "type": "article"
       },
       {
-        "title": "How does OpenAI Function Calling work?",
+        "title": "¿Cómo funciona la Llamada de Funciones de OpenAI?",
         "url": "https://www.youtube.com/watch?v=Qor2VZoBib0",
         "type": "video"
       }
     ]
   },
   "mbp2NoL-VZ5hZIIblNBXt": {
-    "title": "OpenAI Assistant API",
-    "description": "The OpenAI Assistant API enables developers to create advanced conversational systems using models like GPT-4. It supports multi-turn conversations, allowing the AI to maintain context across exchanges, which is ideal for chatbots, virtual assistants, and interactive applications. Developers can customize interactions by defining roles, such as system, user, and assistant, to guide the assistant's behavior. With features like temperature control, token limits, and stop sequences, the API offers flexibility to ensure responses are relevant, safe, and tailored to specific use cases.\n\nLearn more from the following resources:",
+    "title": "API de Asistente de OpenAI",
+    "description": "La API de Asistentes de OpenAI permite a los desarrolladores crear sistemas conversacionales avanzados utilizando modelos como GPT-4. Admite conversaciones de varios turnos, lo que permite a la IA mantener el contexto a través de los intercambios, lo cual es ideal para chatbots, asistentes virtuales y aplicaciones interactivas. Los desarrolladores pueden personalizar las interacciones definiendo roles, como sistema, usuario y asistente, para guiar el comportamiento del asistente. Con funciones como control de temperatura, límites de tokens y secuencias de parada, la API ofrece flexibilidad para garantizar que las respuestas sean relevantes, seguras y adaptadas a casos de uso específicos.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
-        "title": "OpenAI Assistants API – Course for Beginners",
+        "title": "API de Asistentes de OpenAI – Curso para Principiantes",
         "url": "https://www.youtube.com/watch?v=qHPonmSX4Ms",
         "type": "course"
       },
       {
-        "title": "Assistants API",
+        "title": "API de Asistentes",
         "url": "https://platform.openai.com/docs/assistants/overview",
         "type": "article"
       }
     ]
   },
   "W7cKPt_UxcUgwp8J6hS4p": {
-    "title": "Multimodal AI",
-    "description": "Multimodal AI is an approach that combines and processes data from multiple sources, such as text, images, audio, and video, to understand and generate responses. By integrating different data types, it enables more comprehensive and accurate AI systems, allowing for tasks like visual question answering, interactive virtual assistants, and enhanced content understanding. This capability helps create richer, more context-aware applications that can analyze and respond to complex, real-world scenarios.\n\nLearn more from the following resources:",
+    "title": "IA Multimodal",
+    "description": "La IA multimodal es un enfoque que combina y procesa datos de múltiples fuentes, como texto, imágenes, audio y video, para comprender y generar respuestas. Al integrar diferentes tipos de datos, permite sistemas de IA más completos y precisos, lo que permite tareas como la respuesta visual a preguntas, asistentes virtuales interactivos y una mejor comprensión del contenido. Esta capacidad ayuda a crear aplicaciones más ricas y conscientes del contexto que pueden analizar y responder a escenarios complejos del mundo real.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
-        "title": "A Multimodal World - Hugging Face",
+        "title": "Un Mundo Multimodal - Hugging Face",
         "url": "https://huggingface.co/learn/computer-vision-course/en/unit4/multimodal-models/a_multimodal_world",
         "type": "article"
       },
       {
-        "title": "Multimodal AI - Google",
+        "title": "IA Multimodal - Google",
         "url": "https://cloud.google.com/use-cases/multimodal-ai?hl=en",
         "type": "article"
       },
       {
-        "title": "What Is Multimodal AI? A Complete Introduction",
+        "title": "¿Qué es la IA Multimodal? Una Introducción Completa",
         "url": "https://www.splunk.com/en_us/blog/learn/multimodal-ai.html",
         "type": "article"
       }
     ]
   },
   "sGR9qcro68KrzM8qWxcH8": {
-    "title": "Multimodal AI Usecases",
-    "description": "Multimodal AI powers applications like visual question answering, content moderation, and enhanced search engines. It drives smarter virtual assistants and interactive AR apps, combining text, images, and audio for richer, more intuitive user experiences across e-commerce, accessibility, and entertainment.\n\nLearn more from the following resources:",
+    "title": "Casos de Uso de IA Multimodal",
+    "description": "La IA multimodal impulsa aplicaciones como la respuesta visual a preguntas, la moderación de contenido y los motores de búsqueda mejorados. Impulsa asistentes virtuales más inteligentes y aplicaciones de RA interactivas, combinando texto, imágenes y audio para experiencias de usuario más ricas e intuitivas en el comercio electrónico, la accesibilidad y el entretenimiento.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
-        "title": "Hugging Face Multimodal Models",
+        "title": "Modelos Multimodales de Hugging Face",
         "url": "https://huggingface.co/learn/computer-vision-course/en/unit4/multimodal-models/a_multimodal_world",
         "type": "article"
       }
     ]
   },
   "fzVq4hGoa2gdbIzoyY1Zp": {
-    "title": "Image Understanding",
-    "description": "Multimodal AI enhances image understanding by integrating visual data with other types of information, such as text or audio. By combining these inputs, AI models can interpret images more comprehensively, recognizing objects, scenes, and actions, while also understanding context and related concepts. For example, an AI system could analyze an image and generate descriptive captions, or provide explanations based on both visual content and accompanying text.\n\nLearn more from the following resources:",
+    "title": "Comprensión de Imágenes",
+    "description": "La IA multimodal mejora la comprensión de imágenes al integrar datos visuales con otros tipos de información, como texto o audio. Al combinar estas entradas, los modelos de IA pueden interpretar imágenes de manera más completa, reconociendo objetos, escenas y acciones, al mismo tiempo que comprenden el contexto y los conceptos relacionados. Por ejemplo, un sistema de IA podría analizar una imagen y generar subtítulos descriptivos, o proporcionar explicaciones basadas tanto en el contenido visual como en el texto adjunto.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
-        "title": "Low or High Fidelity Image Understanding - OpenAI",
+        "title": "Comprensión de Imágenes de Baja o Alta Fidelidad - OpenAI",
         "url": "https://platform.openai.com/docs/guides/images",
         "type": "article"
       }
     ]
   },
   "49BWxYVFpIgZCCqsikH7l": {
-    "title": "Image Generation",
-    "description": "Image generation is a process in artificial intelligence where models create new images based on input prompts or existing data. It involves using generative models like GANs (Generative Adversarial Networks), VAEs (Variational Autoencoders), or more recently, transformer-based models like DALL-E and Stable Diffusion.\n\nLearn more from the following resources:",
+    "title": "Generación de Imágenes",
+    "description": "La generación de imágenes es un proceso en inteligencia artificial donde los modelos crean nuevas imágenes basadas en prompts de entrada o datos existentes. Implica el uso de modelos generativos como GAN (Redes Generativas Antagónicas), VAE (Autocodificadores Variacionales) o, más recientemente, modelos basados en transformadores como DALL-E y Stable Diffusion.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
         "title": "DALL-E",
@@ -1705,124 +1705,124 @@
         "type": "article"
       },
       {
-        "title": "How DALL-E 2 Actually Works",
+        "title": "Cómo Funciona Realmente DALL-E 2",
         "url": "https://www.assemblyai.com/blog/how-dall-e-2-actually-works/",
         "type": "article"
       },
       {
-        "title": "How AI Image Generators Work (Stable Diffusion / Dall-E)",
+        "title": "Cómo Funcionan los Generadores de Imágenes de IA (Stable Diffusion / Dall-E)",
         "url": "https://www.youtube.com/watch?v=1CIpzeNxIhU",
         "type": "video"
       }
     ]
   },
   "TxaZCtTCTUfwCxAJ2pmND": {
-    "title": "Video Understanding",
-    "description": "Video understanding with multimodal AI involves analyzing and interpreting both visual and audio content to provide a more comprehensive understanding of videos. Common use cases include video summarization, where AI extracts key scenes and generates summaries; content moderation, where the system detects inappropriate visuals or audio; and video indexing for easier search and retrieval of specific moments within a video. Other applications include enhancing video-based recommendations, security surveillance, and interactive entertainment, where video and audio are processed together for real-time user interaction.\n\nLearn more from the following resources:",
+    "title": "Comprensión de Video",
+    "description": "La comprensión de video con IA multimodal implica analizar e interpretar tanto el contenido visual como el de audio para proporcionar una comprensión más completa de los videos. Los casos de uso comunes incluyen el resumen de video, donde la IA extrae escenas clave y genera resúmenes; la moderación de contenido, donde el sistema detecta imágenes o audio inapropiados; y la indexación de video para facilitar la búsqueda y recuperación de momentos específicos dentro de un video. Otras aplicaciones incluyen la mejora de las recomendaciones basadas en video, la vigilancia de seguridad y el entretenimiento interactivo, donde el video y el audio se procesan juntos para la interacción del usuario en tiempo real.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
-        "title": "Awesome LLM for Video Understanding",
+        "title": "Impresionantes LLM para la Comprensión de Video",
         "url": "https://github.com/yunlong10/Awesome-LLMs-for-Video-Understanding",
         "type": "opensource"
       },
       {
-        "title": "Video Understanding",
+        "title": "Comprensión de Video",
         "url": "https://dl.acm.org/doi/10.1145/3503161.3551600",
         "type": "article"
       }
     ]
   },
   "mxQYB820447DC6kogyZIL": {
-    "title": "Audio Processing",
-    "description": "Audio processing in multimodal AI enables a wide range of use cases by combining sound with other data types, such as text, images, or video, to create more context-aware systems. Use cases include speech recognition paired with real-time transcription and visual analysis in meetings or video conferencing tools, voice-controlled virtual assistants that can interpret commands in conjunction with on-screen visuals, and multimedia content analysis where audio and visual elements are analyzed together for tasks like content moderation or video indexing.\n\nLearn more from the following resources:",
+    "title": "Procesamiento de Audio",
+    "description": "El procesamiento de audio en la IA multimodal permite una amplia gama de casos de uso al combinar el sonido con otros tipos de datos, como texto, imágenes o video, para crear sistemas más conscientes del contexto. Los casos de uso incluyen el reconocimiento de voz emparejado con la transcripción en tiempo real y el análisis visual en reuniones o herramientas de videoconferencia, asistentes virtuales controlados por voz que pueden interpretar comandos junto con elementos visuales en pantalla, y análisis de contenido multimedia donde los elementos de audio y visuales se analizan juntos para tareas como la moderación de contenido o la indexación de video.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
-        "title": "The State of Audio Processing",
+        "title": "El Estado del Procesamiento de Audio",
         "url": "https://appwrite.io/blog/post/state-of-audio-processing",
         "type": "article"
       },
       {
-        "title": "Audio Signal Processing for Machine Learning",
+        "title": "Procesamiento de Señales de Audio para Aprendizaje Automático",
         "url": "https://www.youtube.com/watch?v=iCwMQJnKk2c",
         "type": "video"
       }
     ]
   },
   "GCERpLz5BcRtWPpv-asUz": {
-    "title": "Text-to-Speech",
-    "description": "In the context of multimodal AI, text-to-speech (TTS) technology converts written text into natural-sounding spoken language, allowing AI systems to communicate verbally. When integrated with other modalities, such as visual or interactive elements, TTS can enhance user experiences in applications like virtual assistants, educational tools, and accessibility features. For example, a multimodal AI could read aloud text from an on-screen document while highlighting relevant sections, or narrate information about objects recognized in an image. By combining TTS with other forms of data processing, multimodal AI creates more engaging, accessible, and interactive systems for users.\n\nLearn more from the following resources:",
+    "title": "Texto a Voz",
+    "description": "En el contexto de la IA multimodal, la tecnología de texto a voz (TTS) convierte el texto escrito en lenguaje hablado con sonido natural, lo que permite a los sistemas de IA comunicarse verbalmente. Cuando se integra con otras modalidades, como elementos visuales o interactivos, TTS puede mejorar las experiencias de los usuarios en aplicaciones como asistentes virtuales, herramientas educativas y funciones de accesibilidad. Por ejemplo, una IA multimodal podría leer en voz alta el texto de un documento en pantalla mientras resalta secciones relevantes, o narrar información sobre objetos reconocidos en una imagen. Al combinar TTS con otras formas de procesamiento de datos, la IA multimodal crea sistemas más atractivos, accesibles e interactivos para los usuarios.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
-        "title": "What is Text-to-Speech?",
+        "title": "¿Qué es Texto a Voz?",
         "url": "https://aws.amazon.com/polly/what-is-text-to-speech/",
         "type": "article"
       },
       {
-        "title": "From Text to Speech: The Evolution of Synthetic Voices",
+        "title": "De Texto a Voz: La Evolución de las Voces Sintéticas",
         "url": "https://ignitetech.ai/about/blogs/text-speech-evolution-synthetic-voices",
         "type": "article"
       }
     ]
   },
   "jQX10XKd_QM5wdQweEkVJ": {
-    "title": "Speech-to-Text",
-    "description": "In the context of multimodal AI, speech-to-text technology converts spoken language into written text, enabling seamless integration with other data types like images and text. This allows AI systems to process audio input and combine it with visual or textual information, enhancing applications such as virtual assistants, interactive chatbots, and multimedia content analysis. For example, a multimodal AI can transcribe a video’s audio while simultaneously analyzing on-screen visuals and text, providing richer and more context-aware insights.\n\nLearn more from the following resources:",
+    "title": "Voz a Texto",
+    "description": "En el contexto de la IA multimodal, la tecnología de voz a texto convierte el lenguaje hablado en texto escrito, lo que permite una integración perfecta con otros tipos de datos como imágenes y texto. Esto permite a los sistemas de IA procesar la entrada de audio y combinarla con información visual o textual, mejorando aplicaciones como asistentes virtuales, chatbots interactivos y análisis de contenido multimedia. Por ejemplo, una IA multimodal puede transcribir el audio de un video mientras analiza simultáneamente los elementos visuales y el texto en pantalla, proporcionando información más rica y consciente del contexto.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
-        "title": "What is Speech to Text?",
+        "title": "¿Qué es Voz a Texto?",
         "url": "https://aws.amazon.com/what-is/speech-to-text/",
         "type": "article"
       },
       {
-        "title": "Turn Speech into Text using Google AI",
+        "title": "Convierte Voz en Texto usando IA de Google",
         "url": "https://cloud.google.com/speech-to-text",
         "type": "article"
       },
       {
-        "title": "How is Speech to Text Used?",
+        "title": "¿Cómo se Usa Voz a Texto?",
         "url": "https://h2o.ai/wiki/speech-to-text/",
         "type": "article"
       }
     ]
   },
   "CRrqa-dBw1LlOwVbrZhjK": {
-    "title": "OpenAI Vision API",
-    "description": "The OpenAI Vision API enables models to analyze and understand images, allowing them to identify objects, recognize text, and interpret visual content. It integrates image processing with natural language capabilities, enabling tasks like visual question answering, image captioning, and extracting information from photos. This API can be used for applications in accessibility, content moderation, and automation, providing a seamless way to combine visual understanding with text-based interactions.\n\nLearn more from the following resources:",
+    "title": "API de Visión de OpenAI",
+    "description": "La API de Visión de OpenAI permite a los modelos analizar y comprender imágenes, permitiéndoles identificar objetos, reconocer texto e interpretar contenido visual. Integra el procesamiento de imágenes con capacidades de lenguaje natural, lo que permite tareas como la respuesta visual a preguntas, la generación de subtítulos de imágenes y la extracción de información de fotos. Esta API se puede utilizar para aplicaciones en accesibilidad, moderación de contenido y automatización, proporcionando una forma perfecta de combinar la comprensión visual con las interacciones basadas en texto.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
-        "title": "Vision",
+        "title": "Visión",
         "url": "https://platform.openai.com/docs/guides/vision",
         "type": "article"
       },
       {
-        "title": "OpenAI Vision API Crash Course",
+        "title": "Curso Intensivo de la API de Visión de OpenAI",
         "url": "https://www.youtube.com/watch?v=ZjkS11DSeEk",
         "type": "video"
       }
     ]
   },
   "LKFwwjtcawJ4Z12X102Cb": {
-    "title": "DALL-E API",
-    "description": "The DALL-E API is a tool provided by OpenAI that allows developers to integrate the DALL-E image generation model into applications. DALL-E is an AI model designed to generate images from textual descriptions, capable of producing highly detailed and creative visuals. The API enables users to provide a descriptive prompt, and the model generates corresponding images, opening up possibilities in fields like design, advertising, content creation, and art.\n\nLearn more from the following resources:",
+    "title": "API de DALL-E",
+    "description": "La API de DALL-E es una herramienta proporcionada por OpenAI que permite a los desarrolladores integrar el modelo de generación de imágenes DALL-E en las aplicaciones. DALL-E es un modelo de IA diseñado para generar imágenes a partir de descripciones textuales, capaz de producir imágenes muy detalladas y creativas. La API permite a los usuarios proporcionar un prompt descriptivo, y el modelo genera las imágenes correspondientes, abriendo posibilidades en campos como el diseño, la publicidad, la creación de contenido y el arte.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
-        "title": "OpenAI Image Generation",
+        "title": "Generación de Imágenes de OpenAI",
         "url": "https://platform.openai.com/docs/guides/images",
         "type": "article"
       },
       {
-        "title": "DALL E API - Introduction (Generative AI Pictures from OpenAI)",
+        "title": "API de DALL E - Introducción (Imágenes Generativas de IA de OpenAI)",
         "url": "https://www.youtube.com/watch?v=Zr6vAWwjHN0",
         "type": "video"
       }
     ]
   },
   "OTBd6cPUayKaAM-fLWdSt": {
-    "title": "Whisper API",
-    "description": "The Whisper API by OpenAI enables developers to integrate speech-to-text capabilities into their applications. It uses OpenAI's Whisper model, a powerful speech recognition system, to convert spoken language into accurate, readable text. The API supports multiple languages and can handle various accents, making it ideal for tasks like transcription, voice commands, and automated captions. With the ability to process audio in real time or from pre-recorded files, the Whisper API simplifies adding robust speech recognition features to applications, enhancing accessibility and enabling new interactive experiences.\n\nLearn more from the following resources:",
+    "title": "API de Whisper",
+    "description": "La API de Whisper de OpenAI permite a los desarrolladores integrar capacidades de voz a texto en sus aplicaciones. Utiliza el modelo Whisper de OpenAI, un potente sistema de reconocimiento de voz, para convertir el lenguaje hablado en texto preciso y legible. La API admite múltiples idiomas y puede manejar varios acentos, lo que la hace ideal para tareas como transcripción, comandos de voz y subtítulos automatizados. Con la capacidad de procesar audio en tiempo real o desde archivos pregrabados, la API de Whisper simplifica la adición de funciones sólidas de reconocimiento de voz a las aplicaciones, mejorando la accesibilidad y permitiendo nuevas experiencias interactivas.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
-        "title": "Whisper on GitHub",
+        "title": "Whisper en GitHub",
         "url": "https://github.com/openai/whisper",
         "type": "opensource"
       },
@@ -1834,24 +1834,24 @@
     ]
   },
   "EIDbwbdolR_qsNKVDla6V": {
-    "title": "Hugging Face Models",
-    "description": "Hugging Face models are a collection of pre-trained machine learning models available through the Hugging Face platform, covering a wide range of tasks like natural language processing, computer vision, and audio processing. The platform includes models for tasks such as text classification, translation, summarization, question answering, and more, with popular models like BERT, GPT, T5, and CLIP. Hugging Face provides easy-to-use tools and APIs that allow developers to access, fine-tune, and deploy these models, fostering a collaborative community where users can share, modify, and contribute models to improve AI research and application development.\n\nLearn more from the following resources:",
+    "title": "Modelos de Hugging Face",
+    "description": "Los modelos de Hugging Face son una colección de modelos de aprendizaje automático preentrenados disponibles a través de la plataforma Hugging Face, que cubren una amplia gama de tareas como el procesamiento del lenguaje natural, la visión por computadora y el procesamiento de audio. La plataforma incluye modelos para tareas como clasificación de texto, traducción, resumen, respuesta a preguntas y más, con modelos populares como BERT, GPT, T5 y CLIP. Hugging Face proporciona herramientas y API fáciles de usar que permiten a los desarrolladores acceder, ajustar e implementar estos modelos, fomentando una comunidad colaborativa donde los usuarios pueden compartir, modificar y contribuir con modelos para mejorar la investigación de IA y el desarrollo de aplicaciones.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
-        "title": "Hugging Face Models",
+        "title": "Modelos de Hugging Face",
         "url": "https://huggingface.co/models",
         "type": "article"
       },
       {
-        "title": "How to Use Pretrained Models from Hugging Face in a Few Lines of Code",
+        "title": "Cómo Usar Modelos Preentrenados de Hugging Face en Pocas Líneas de Código",
         "url": "https://www.youtube.com/watch?v=ntz160EnWIc",
         "type": "video"
       }
     ]
   },
   "j9zD3pHysB1CBhLfLjhpD": {
-    "title": "LangChain for Multimodal Apps",
-    "description": "LangChain is a framework designed to build applications that integrate multiple AI models, especially those focusing on language understanding, generation, and multimodal capabilities. For multimodal apps, LangChain facilitates seamless interaction between text, image, and even audio models, enabling developers to create complex workflows that can process and analyze different types of data.\n\nLearn more from the following resources:",
+    "title": "LangChain para Aplicaciones Multimodales",
+    "description": "LangChain es un marco diseñado para crear aplicaciones que integran múltiples modelos de IA, especialmente aquellos centrados en la comprensión, generación de lenguaje y capacidades multimodales. Para aplicaciones multimodales, LangChain facilita la interacción fluida entre modelos de texto, imagen e incluso audio, lo que permite a los desarrolladores crear flujos de trabajo complejos que pueden procesar y analizar diferentes tipos de datos.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
         "title": "LangChain",
@@ -1859,44 +1859,44 @@
         "type": "article"
       },
       {
-        "title": "Build a Multimodal GenAI App with LangChain and Gemini LLMs",
+        "title": "Construye una Aplicación GenAI Multimodal con LangChain y LLMs Gemini",
         "url": "https://www.youtube.com/watch?v=bToMzuiOMhg",
         "type": "video"
       }
     ]
   },
   "akQTCKuPRRelj2GORqvsh": {
-    "title": "LlamaIndex for Multimodal Apps",
-    "description": "LlamaIndex enables multi-modal apps by linking language models (LLMs) to diverse data sources, including text and images. It indexes and retrieves information across formats, allowing LLMs to process and integrate data from multiple modalities. This supports applications like visual question answering, content summarization, and interactive systems by providing structured, context-aware inputs from various content types.\n\nLearn more from the following resources:",
+    "title": "LlamaIndex para Aplicaciones Multimodales",
+    "description": "LlamaIndex habilita aplicaciones multimodales al vincular modelos de lenguaje (LLM) a diversas fuentes de datos, incluidos texto e imágenes. Indexa y recupera información en todos los formatos, lo que permite a los LLM procesar e integrar datos de múltiples modalidades. Esto admite aplicaciones como respuesta visual a preguntas, resumen de contenido y sistemas interactivos al proporcionar entradas estructuradas y conscientes del contexto de varios tipos de contenido.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
-        "title": "LlamaIndex Multi-modal",
+        "title": "LlamaIndex Multimodal",
         "url": "https://docs.llamaindex.ai/en/stable/use_cases/multimodal/",
         "type": "article"
       },
       {
-        "title": "Multi-modal Retrieval Augmented Generation with LlamaIndex",
+        "title": "Generación Aumentada por Recuperación Multimodal con LlamaIndex",
         "url": "https://www.youtube.com/watch?v=35RlrrgYDyU",
         "type": "video"
       }
     ]
   },
   "NYge7PNtfI-y6QWefXJ4d": {
-    "title": "Development Tools",
-    "description": "AI has given rise to a collection of AI powered development tools of various different varieties. We have IDEs like Cursor that has AI baked into it, live context capturing tools such as Pieces and a variety of brower based tools like V0, Claude and more.\n\nLearn more from the following resources:",
+    "title": "Herramientas de Desarrollo",
+    "description": "La IA ha dado lugar a una colección de herramientas de desarrollo impulsadas por IA de diversas variedades. Tenemos IDE como Cursor que tiene IA integrada, herramientas de captura de contexto en vivo como Pieces y una variedad de herramientas basadas en navegador como V0, Claude y más.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
-        "title": "v0 Website",
+        "title": "Sitio Web de v0",
         "url": "https://v0.dev",
         "type": "article"
       },
       {
-        "title": "Aider - AI Pair Programming in Terminal",
+        "title": "Aider - Programación en Pareja con IA en la Terminal",
         "url": "https://aider.chat/",
         "type": "article"
       },
       {
-        "title": "Replit AI",
+        "title": "IA de Replit",
         "url": "https://replit.com/ai",
         "type": "article"
       },
@@ -1908,39 +1908,39 @@
     ]
   },
   "XcKeQfpTA5ITgdX51I4y-": {
-    "title": "AI Code Editors",
-    "description": "AI code editors are development tools that leverage artificial intelligence to assist software developers in writing, debugging, and optimizing code. These editors go beyond traditional syntax highlighting and code completion by incorporating machine learning models, natural language processing, and data analysis to understand code context, generate suggestions, and even automate portions of the software development process.\n\nVisit the following resources to learn more:",
+    "title": "Editores de Código con IA",
+    "description": "Los editores de código con IA son herramientas de desarrollo que aprovechan la inteligencia artificial para ayudar a los desarrolladores de software a escribir, depurar y optimizar código. Estos editores van más allá del resaltado de sintaxis tradicional y la finalización de código al incorporar modelos de aprendizaje automático, procesamiento del lenguaje natural y análisis de datos para comprender el contexto del código, generar sugerencias e incluso automatizar partes del proceso de desarrollo de software.\n\nVisita los siguientes recursos para aprender más:",
     "links": [
       {
-        "title": "Cursor - The AI Code Editor",
+        "title": "Cursor - El Editor de Código con IA",
         "url": "https://www.cursor.com/",
         "type": "website"
       },
       {
-        "title": "PearAI - The Open Source, Extendable AI Code Editor",
+        "title": "PearAI - El Editor de Código con IA Extensible y de Código Abierto",
         "url": "https://trypear.ai/",
         "type": "website"
       },
       {
-        "title": "Bolt - Prompt, run, edit, and deploy full-stack web apps",
+        "title": "Bolt - Crea, ejecuta, edita e implementa aplicaciones web full-stack",
         "url": "https://bolt.new",
         "type": "website"
       },
       {
-        "title": "Replit - Build Apps using AI",
+        "title": "Replit - Construye Aplicaciones usando IA",
         "url": "https://replit.com/ai",
         "type": "website"
       },
       {
-        "title": "v0 - Build Apps with AI",
+        "title": "v0 - Construye Aplicaciones con IA",
         "url": "https://v0.dev",
         "type": "website"
       }
     ]
   },
   "TifVhqFm1zXNssA8QR3SM": {
-    "title": "Code Completion Tools",
-    "description": "Code completion tools are AI-powered development assistants designed to enhance productivity by automatically suggesting code snippets, functions, and entire blocks of code as developers type. These tools, such as GitHub Copilot and Tabnine, leverage machine learning models trained on vast code repositories to predict and generate contextually relevant code. They help reduce repetitive coding tasks, minimize errors, and accelerate the development process by offering real-time, intelligent suggestions.\n\nLearn more from the following resources:",
+    "title": "Herramientas de Finalización de Código",
+    "description": "Las herramientas de finalización de código son asistentes de desarrollo impulsados por IA diseñados para mejorar la productividad sugiriendo automáticamente fragmentos de código, funciones y bloques completos de código a medida que los desarrolladores escriben. Estas herramientas, como GitHub Copilot y Tabnine, aprovechan los modelos de aprendizaje automático entrenados en vastos repositorios de código para predecir y generar código contextualmente relevante. Ayudan a reducir las tareas de codificación repetitivas, minimizar errores y acelerar el proceso de desarrollo ofreciendo sugerencias inteligentes en tiempo real.\n\nAprende más de los siguientes recursos:",
     "links": [
       {
         "title": "GitHub Copilot",

--- a/public/roadmap-content/android.json
+++ b/public/roadmap-content/android.json
@@ -1,10 +1,10 @@
 {
   "Suws-7f_6Z1ChpfcnxX2M": {
-    "title": "Pick a Language",
-    "description": "When developing for Android, one crucial step is picking a programming language to use. There are multiple languages you can choose from, but the three most popular ones are Java, Kotlin, and C++.\n\nJava is the original language used for Android development and is widely used, making it a good choice for beginners due to the wealth of resources and developer communities. Kotlin is a newer option that is fully supported by Google and Android Studio, and addressing many of the drawbacks of Java which makes it a popular choice for many developers.\n\nVisit the following resources to learn more:",
+    "title": "Elige un Lenguaje",
+    "description": "Al desarrollar para Android, un paso crucial es elegir un lenguaje de programación. Hay varios lenguajes entre los que puedes elegir, pero los tres más populares son Java, Kotlin y C++.\n\nJava es el lenguaje original utilizado para el desarrollo de Android y es ampliamente utilizado, lo que lo convierte en una buena opción para principiantes debido a la gran cantidad de recursos y comunidades de desarrolladores. Kotlin es una opción más nueva que es totalmente compatible con Google y Android Studio, y soluciona muchas de las desventajas de Java, lo que la convierte en una opción popular para muchos desarrolladores.\n\nVisita los siguientes recursos para obtener más información:",
     "links": [
       {
-        "title": "Pick a Language",
+        "title": "Elige un Lenguaje",
         "url": "https://developer.android.com/studio/write/java8-support",
         "type": "article"
       },
@@ -17,7 +17,7 @@
   },
   "qIzUv8-GgQnkqChEdgD50": {
     "title": "Kotlin",
-    "description": "`Kotlin` is a cross-platform, statically typed general-purpose programming language with type inference. Developed by JetBrains, the makers of the world’s leading IDEs, Kotlin has a syntax, which is more expressive and concise. This allows for more readable and maintainable code. It is fully interoperable with Java and comes with no limitations. It can be used almost everywhere Java is used today, for server-side development, Android apps, and much more. Kotlin introduces several improvements for programmers over Java, which makes it a preferred choice for many developers. With more concise code base and modern programming concept support - it's certainly a future of Android app development.\n\nVisit the following resources to learn more:",
+    "description": "`Kotlin` es un lenguaje de programación de propósito general, multiplataforma y de tipado estático con inferencia de tipos. Desarrollado por JetBrains, los creadores de los IDE líderes en el mundo, Kotlin tiene una sintaxis más expresiva y concisa. Esto permite un código más legible y fácil de mantener. Es totalmente interoperable con Java y no tiene limitaciones. Se puede usar en casi cualquier lugar donde se usa Java hoy en día, para desarrollo del lado del servidor, aplicaciones de Android y mucho más. Kotlin introduce varias mejoras para los programadores sobre Java, lo que lo convierte en la opción preferida de muchos desarrolladores. Con una base de código más concisa y compatibilidad con conceptos de programación modernos, es sin duda el futuro del desarrollo de aplicaciones de Android.\n\nVisita los siguientes recursos para obtener más información:",
     "links": [
       {
         "title": "Kotlin",
@@ -25,17 +25,17 @@
         "type": "article"
       },
       {
-        "title": "Kotlin Documentation",
+        "title": "Documentación de Kotlin",
         "url": "https://kotlinlang.org/docs/home.html",
         "type": "article"
       },
       {
-        "title": "Learn Kotlin - w3schools",
+        "title": "Aprende Kotlin - w3schools",
         "url": "https://www.w3schools.com/kotlin/",
         "type": "article"
       },
       {
-        "title": "Learn Kotlin Programming for Beginners - Free Code Camp",
+        "title": "Aprende Programación en Kotlin para Principiantes - Free Code Camp",
         "url": "https://youtu.be/EExSSotojVI?si=4VPW8ZHa2UMX0HH1",
         "type": "video"
       }
@@ -43,10 +43,10 @@
   },
   "RBABbkzD_uNFwEO-hssZO": {
     "title": "Java",
-    "description": "Java is a popular programming language used for Android development due to its robustness and ease of use. Its object-oriented structure allows developers to create modular programs and reusable code. The language was built with the philosophy of \"write once, run anywhere\" (WORA), meaning compiled Java code can run on all platforms without the need for recompilation. Android’s API and core libraries are primarily written in Java, therefore understanding Java is fundamental in creating diverse and powerful Android apps.\n\nVisit the following resources to learn more:",
+    "description": "Java es un lenguaje de programación popular utilizado para el desarrollo de Android debido a su robustez y facilidad de uso. Su estructura orientada a objetos permite a los desarrolladores crear programas modulares y código reutilizable. El lenguaje se construyó con la filosofía de \"escribir una vez, ejecutar en cualquier lugar\" (WORA), lo que significa que el código Java compilado puede ejecutarse en todas las plataformas sin necesidad de recompilación. La API y las bibliotecas principales de Android están escritas principalmente en Java, por lo tanto, comprender Java es fundamental para crear aplicaciones de Android diversas y potentes.\n\nVisita los siguientes recursos para obtener más información:",
     "links": [
       {
-        "title": "Java Roadmap",
+        "title": "Roadmap de Java",
         "url": "https://roadmap.sh/java",
         "type": "article"
       },
@@ -56,7 +56,7 @@
         "type": "article"
       },
       {
-        "title": "Java Documentation",
+        "title": "Documentación de Java",
         "url": "https://docs.oracle.com/en/java/javase/11/docs/api/",
         "type": "article"
       }

--- a/public/roadmap-content/angular.json
+++ b/public/roadmap-content/angular.json
@@ -1,72 +1,72 @@
 {
   "KDd40JOAvZ8O1mfhTYB3K": {
-    "title": "Introduction to Angular",
-    "description": "Angular is a popular open-source front-end web application framework developed by Google. It is written in TypeScript and allows developers to build dynamic, single-page web applications with ease. Angular provides a comprehensive set of features for creating interactive and responsive user interfaces, making it a powerful tool for modern web development.\n\nOne of the key features of Angular is its use of components, which are reusable building blocks for creating web applications. Components encapsulate the HTML, CSS, and TypeScript code needed to define a specific part of a web page, making it easier to manage and maintain complex applications. Angular also includes a powerful dependency injection system, which helps manage the dependencies between different parts of an application and promotes code reusability. Additionally, Angular provides tools for routing, form handling, and state management, making it a versatile framework for building a wide range of web applications.\n\nLearn more from the following resources:",
+    "title": "Introducción a Angular",
+    "description": "Angular es un popular framework de aplicaciones web front-end de código abierto desarrollado por Google. Está escrito en TypeScript y permite a los desarrolladores crear aplicaciones web dinámicas de una sola página con facilidad. Angular proporciona un conjunto completo de características para crear interfaces de usuario interactivas y receptivas, lo que lo convierte en una herramienta poderosa para el desarrollo web moderno.\n\nUna de las características clave de Angular es el uso de componentes, que son bloques de construcción reutilizables para crear aplicaciones web. Los componentes encapsulan el código HTML, CSS y TypeScript necesario para definir una parte específica de una página web, lo que facilita la gestión y el mantenimiento de aplicaciones complejas. Angular también incluye un potente sistema de inyección de dependencias, que ayuda a gestionar las dependencias entre diferentes partes de una aplicación y promueve la reutilización del código. Además, Angular proporciona herramientas para el enrutamiento, el manejo de formularios y la gestión del estado, lo que lo convierte en un framework versátil para crear una amplia gama de aplicaciones web.\n\nObtenga más información de los siguientes recursos:",
     "links": [
       {
-        "title": " Angular website",
+        "title": "Sitio web de Angular",
         "url": "https://angular.dev/",
         "type": "article"
       }
     ]
   },
   "DE3cMpeRYuUPw2ADtfS-3": {
-    "title": "Angular Architecture",
-    "description": "Angular follows a modular architecture pattern, dividing the application into distinct modules, components, services, and other elements, which enhances code organization and maintainability. The key building blocks include modules, which are containers grouping related components, services, directives, and other elements to ensure proper encapsulation and reusability. Components are the building blocks of Angular applications, representing parts of the user interface with associated logic, consisting of templates, styles, and a class defining behavior. Services encapsulate reusable business logic, data manipulation, and API communication, enabling data and functionality sharing across components. Directives are HTML attributes or elements that extend HTML functionality, allowing reusable behaviors across the application. Lastly, pipes transform data before displaying it in templates, providing convenient ways to format, filter, and sort data.\n\nVisit the following resources to learn more:",
+    "title": "Arquitectura de Angular",
+    "description": "Angular sigue un patrón de arquitectura modular, dividiendo la aplicación en módulos, componentes, servicios y otros elementos distintos, lo que mejora la organización y el mantenimiento del código. Los bloques de construcción clave incluyen módulos, que son contenedores que agrupan componentes, servicios, directivas y otros elementos relacionados para garantizar una encapsulación y reutilización adecuadas. Los componentes son los bloques de construcción de las aplicaciones de Angular, que representan partes de la interfaz de usuario con lógica asociada, y constan de plantillas, estilos y una clase que define el comportamiento. Los servicios encapsulan la lógica de negocio reutilizable, la manipulación de datos y la comunicación API, lo que permite compartir datos y funcionalidades entre componentes. Las directivas son atributos o elementos HTML que amplían la funcionalidad HTML, lo que permite comportamientos reutilizables en toda la aplicación. Por último, los pipes transforman los datos antes de mostrarlos en las plantillas, proporcionando formas convenientes de formatear, filtrar y ordenar los datos.\n\nVisita los siguientes recursos para obtener más información:",
     "links": [
       {
-        "title": "Angular coding style guide",
+        "title": "Guía de estilo de codificación de Angular",
         "url": "https://angular.dev/style-guide",
         "type": "article"
       },
       {
-        "title": "The Ultimate Guide to Angular Architecture: Best Practices for efficient coding with Angular Framework",
+        "title": "La Guía Definitiva de la Arquitectura Angular: Mejores Prácticas para una codificación eficiente con el Framework Angular",
         "url": "https://angulardive.com/blog/the-ultimate-guide-to-angular-architecture-best-practices-for-efficient-coding-with-angular-framework/",
         "type": "article"
       },
       {
-        "title": "Modern Architectures with Angular Part 1: Strategic design with Sheriff and Standalone Components",
+        "title": "Arquitecturas Modernas con Angular Parte 1: Diseño estratégico con Sheriff y Componentes Independientes",
         "url": "https://www.angulararchitects.io/en/blog/modern-architectures-with-angular-part-1-strategic-design-with-sheriff-and-standalone-components/",
         "type": "article"
       },
       {
-        "title": "Optimizing the architecture of large web applications with Angular",
+        "title": "Optimizando la arquitectura de grandes aplicaciones web con Angular",
         "url": "https://albertobasalo.medium.com/optimizing-the-architecture-of-large-web-applications-with-angular-79d03b01a92b",
         "type": "article"
       },
       {
-        "title": "Angular Architecture Concepts and Patterns",
+        "title": "Conceptos y Patrones de Arquitectura Angular",
         "url": "https://www.bigscal.com/blogs/frontend/angular-architecture-concepts-and-patterns/",
         "type": "article"
       },
       {
-        "title": "Top 10 Angular Architecture Mistakes",
+        "title": "Los 10 Principales Errores de Arquitectura Angular",
         "url": "https://angularexperts.io/blog/top-10-angular-architecture-mistakes",
         "type": "article"
       },
       {
-        "title": "Architecting Angular: A Guide to effective project structure",
+        "title": "Arquitectando Angular: Una Guía para una estructura de proyecto efectiva",
         "url": "https://medium.com/@nile.bits/architecting-angular-a-guide-to-effective-project-structure-9756bae92262",
         "type": "article"
       }
     ]
   },
   "EbFRcy4s6yzzIApBqU77Y": {
-    "title": "Setting up a New Project",
-    "description": "Visit the following resources to learn more:",
+    "title": "Configuración de un Nuevo Proyecto",
+    "description": "Visita los siguientes recursos para obtener más información:",
     "links": [
       {
-        "title": "Installation",
+        "title": "Instalación",
         "url": "https://angular.dev/installation",
         "type": "article"
       },
       {
-        "title": "Setting up the local environment and workspace",
+        "title": "Configuración del entorno local y el espacio de trabajo",
         "url": "https://angular.dev/tools/cli/setup-local",
         "type": "article"
       },
       {
-        "title": "Build your first Angular app",
+        "title": "Construye tu primera aplicación Angular",
         "url": "https://angular.dev/tutorials/first-app",
         "type": "article"
       }

--- a/public/roadmap-content/api-design.json
+++ b/public/roadmap-content/api-design.json
@@ -1,15 +1,15 @@
 {
   "duKkpzPjUU_-8kyJGHqRX": {
-    "title": "Learn the Basics",
-    "description": "Application Programming Interfaces (APIs) are an integral part of modern development, allowing software applications to communicate and use functions from other software applications or services. API design, therefore, becomes a key part of any software development process. Furthermore, the basics of API design encompass understanding the principles of what an API is, how it works, and the various types of APIs, such as REST, SOAP, and GraphQL. This also includes understanding the standards and best practices in API design to ensure the development of powerful, user-friendly, and secure APIs. The foundation of API Design lies in this knowledge, setting the stage for more complex API designing and development.",
+    "title": "Aprende los Fundamentos",
+    "description": "Las Interfaces de Programación de Aplicaciones (API) son una parte integral del desarrollo moderno, permitiendo que las aplicaciones de software se comuniquen y utilicen funciones de otras aplicaciones o servicios de software. El diseño de API, por lo tanto, se convierte en una parte clave de cualquier proceso de desarrollo de software. Además, los fundamentos del diseño de API abarcan la comprensión de los principios de qué es una API, cómo funciona y los diversos tipos de API, como REST, SOAP y GraphQL. Esto también incluye la comprensión de los estándares y las mejores prácticas en el diseño de API para garantizar el desarrollo de API potentes, fáciles de usar y seguras. La base del diseño de API radica en este conocimiento, sentando las bases para un diseño y desarrollo de API más complejos.",
     "links": []
   },
   "r8M3quACGO2piu0u_R4hO": {
-    "title": "What are APIs",
-    "description": "APIs, or Application Programming Interfaces, provide a manner in which software applications communicate with each other. They abstract the complexity of applications to allow developers to use only the essentials of the software they are working with. They define the methods and data formats an application should use in order to perform tasks, like sending, retrieving, or modifying data. Understanding APIs is integral to mastering modern software development, primarily because they allow applications to exchange data and functionality with ease, thus enabling integration and convergence of technological services. Therefore, a solid understanding of what APIs are forms the basic cornerstone of API design.\n\nVisit the following resources to learn more:",
+    "title": "¿Qué son las API?",
+    "description": "Las API, o Interfaces de Programación de Aplicaciones, proporcionan una forma en que las aplicaciones de software se comunican entre sí. Abstraen la complejidad de las aplicaciones para permitir a los desarrolladores utilizar solo lo esencial del software con el que están trabajando. Definen los métodos y formatos de datos que una aplicación debe utilizar para realizar tareas, como enviar, recuperar o modificar datos. Comprender las API es fundamental para dominar el desarrollo de software moderno, principalmente porque permiten que las aplicaciones intercambien datos y funcionalidades con facilidad, lo que permite la integración y la convergencia de los servicios tecnológicos. Por lo tanto, una sólida comprensión de lo que son las API constituye la piedra angular básica del diseño de API.\n\nVisita los siguientes recursos para obtener más información:",
     "links": [
       {
-        "title": "Getting Started with APIs - Postman",
+        "title": "Primeros Pasos con las API - Postman",
         "url": "https://www.postman.com/what-is-an-api/",
         "type": "article"
       },
@@ -19,12 +19,12 @@
         "type": "article"
       },
       {
-        "title": "What is an API? - AWS",
+        "title": "¿Qué es una API? - AWS",
         "url": "https://aws.amazon.com/what-is/api/",
         "type": "article"
       },
       {
-        "title": "What is an API?",
+        "title": "¿Qué es una API?",
         "url": "https://www.youtube.com/watch?v=s7wmiS2mSXY",
         "type": "video"
       }
@@ -32,30 +32,30 @@
   },
   "2HdKzAIQi15pr3YHHrbPp": {
     "title": "HTTP",
-    "description": "HTTP, or Hypertext Transfer Protocol, is a fundamental piece of any API design. It is the protocol used for transmitting hypermedia data on the web, such as HTML webpages or JSON from a web API. Understanding HTTP is crucial in API design as it provides the structure for how requests and responses should be constructed and handled. It dictates how endpoints are defined, how data should be transferred, and what status codes should be used to convey specific scenarios. A solid grounding in HTTP principles allows for more robust, efficient and secure API designs.\n\nVisit the following resources to learn more:",
+    "description": "HTTP, o Protocolo de Transferencia de Hipertexto, es una pieza fundamental de cualquier diseño de API. Es el protocolo utilizado para transmitir datos de hipermedia en la web, como páginas web HTML o JSON de una API web. Comprender HTTP es crucial en el diseño de API, ya que proporciona la estructura de cómo se deben construir y manejar las solicitudes y respuestas. Dicta cómo se definen los puntos finales, cómo se deben transferir los datos y qué códigos de estado se deben usar para transmitir escenarios específicos. Una base sólida en los principios de HTTP permite diseños de API más robustos, eficientes y seguros.\n\nVisita los siguientes recursos para obtener más información:",
     "links": [
       {
-        "title": "Everything you need to know about HTTP",
+        "title": "Todo lo que necesitas saber sobre HTTP",
         "url": "https://cs.fyi/guide/http-in-depth",
         "type": "article"
       },
       {
-        "title": "What is HTTP?",
+        "title": "¿Qué es HTTP?",
         "url": "https://www.cloudflare.com/en-gb/learning/ddos/glossary/hypertext-transfer-protocol-http/",
         "type": "article"
       },
       {
-        "title": "An overview of HTTP",
+        "title": "Una visión general de HTTP",
         "url": "https://developer.mozilla.org/en-US/docs/Web/HTTP/Overview",
         "type": "article"
       },
       {
-        "title": "HTTP/3 From A To Z: Core Concepts",
+        "title": "HTTP/3 de la A a la Z: Conceptos Fundamentales",
         "url": "https://www.smashingmagazine.com/2021/08/http3-core-concepts-part1/",
         "type": "article"
       },
       {
-        "title": "HTTP Crash Course & Exploration",
+        "title": "Curso Intensivo y Exploración de HTTP",
         "url": "https://www.youtube.com/watch?v=iYM2zFP3Zn0",
         "type": "video"
       }

--- a/public/roadmap-content/aspnet-core.json
+++ b/public/roadmap-content/aspnet-core.json
@@ -1,25 +1,25 @@
 {
   "NEnna_8DstfYH4T9qrP3-": {
-    "title": "General Development Skills",
-    "description": "There are several skills that are generally considered to be important for working with .NET and C#:\n\n*   Object-oriented programming: Understanding the concepts of classes, objects, inheritance, and polymorphism is essential for working with C# and the .NET Framework.\n    \n*   C# language: A strong understanding of the C# language, including its syntax, keywords, and built-in classes and types, is necessary for writing efficient and maintainable code.\n    \n*   .NET Framework: Familiarity with the .NET Framework, including the Common Language Runtime (CLR) and the Base Class Library (BCL), is important for understanding how C# code is executed and for utilizing the framework's many built-in features.\n    \n*   Web & Software development: Knowledge of web development technologies such as HTML, CSS, JavaScript, and [ASP.NET](http://ASP.NET) is important for creating web applications using C# and the .NET Framework and knowledge of software development methodologies such as Agile, Scrum, or Waterfall is also useful.\n    \n*   Database: Familiarity with database concepts and technologies, such as SQL and [ADO.NET](http://ADO.NET), is important for working with data in C# applications.\n    \n*   Cloud computing: Familiarity with cloud computing concepts and technologies, such as Azure, is becoming increasingly important for deploying and scaling C# applications.\n    \n*   DevOps: Understanding of DevOps concepts and practices, such as continuous integration and continuous deployment, is necessary for automating and streamlining the software development process.\n    \n\nFor more information, visit the following links:",
+    "title": "Habilidades Generales de Desarrollo",
+    "description": "Hay varias habilidades que generalmente se consideran importantes para trabajar con .NET y C#:\n\n*   Programación orientada a objetos: Comprender los conceptos de clases, objetos, herencia y polimorfismo es esencial para trabajar con C# y .NET Framework.\n    \n*   Lenguaje C#: Un sólido conocimiento del lenguaje C#, incluida su sintaxis, palabras clave y clases y tipos integrados, es necesario para escribir código eficiente y mantenible.\n    \n*   .NET Framework: La familiaridad con .NET Framework, incluido Common Language Runtime (CLR) y la Biblioteca de clases base (BCL), es importante para comprender cómo se ejecuta el código C# y para utilizar las numerosas funciones integradas del framework.\n    \n*   Desarrollo web y de software: El conocimiento de tecnologías de desarrollo web como HTML, CSS, JavaScript y [ASP.NET](http://ASP.NET) es importante para crear aplicaciones web con C# y .NET Framework, y el conocimiento de metodologías de desarrollo de software como Agile, Scrum o Waterfall también es útil.\n    \n*   Base de datos: La familiaridad con los conceptos y tecnologías de bases de datos, como SQL y [ADO.NET](http://ADO.NET), es importante para trabajar con datos en aplicaciones C#.\n    \n*   Computación en la nube: La familiaridad con los conceptos y tecnologías de computación en la nube, como Azure, es cada vez más importante para implementar y escalar aplicaciones C#.\n    \n*   DevOps: La comprensión de los conceptos y prácticas de DevOps, como la integración continua y la implementación continua, es necesaria para automatizar y optimizar el proceso de desarrollo de software.\n    \n\nPara obtener más información, visite los siguientes enlaces:",
     "links": [
       {
-        "title": "Explore top posts about Career",
+        "title": "Explora las principales publicaciones sobre Carrera",
         "url": "https://app.daily.dev/tags/career?ref=roadmapsh",
         "type": "article"
       },
       {
-        "title": "Asp.net - Complete Tutorial",
+        "title": "Asp.net - Tutorial Completo",
         "url": "https://www.youtube.com/watch?v=kdPtNMb8tPw",
         "type": "video"
       },
       {
-        "title": "Learn Cloud Computing",
+        "title": "Aprende Computación en la Nube",
         "url": "https://www.youtube.com/watch?v=eWwK2FKWp0g",
         "type": "video"
       },
       {
-        "title": "DevOps Course for Beginners",
+        "title": "Curso de DevOps para Principiantes",
         "url": "https://www.youtube.com/watch?v=hQcFE0RD0cQ",
         "type": "video"
       }
@@ -27,30 +27,30 @@
   },
   "fxANnSiTb2VzA9u-YeBL1": {
     "title": "C#",
-    "description": "C# is a modern coding language that was developed by Microsoft that focuses on applying the coding style to C++ and making it so that way it's more condensed and simple. It's similar to Java by both being static, strong, and manifestive languages. Both use the System's prebuilt class to do certain features like printing output to the screen, etc.C#, like Java, also contains a garbage collection, which removes lower-level maintenance code from the programmer.\n\nVisit the following resources to learn more:",
+    "description": "C# es un lenguaje de codificación moderno desarrollado por Microsoft que se centra en aplicar el estilo de codificación a C++ y hacerlo más condensado y simple. Es similar a Java en que ambos son lenguajes estáticos, fuertes y manifestantes. Ambos usan la clase preconstruida del sistema para realizar ciertas funciones como imprimir salida en la pantalla, etc. C#, como Java, también contiene una recolección de basura, que elimina el código de mantenimiento de bajo nivel del programador.\n\nVisita los siguientes recursos para obtener más información:",
     "links": [
       {
-        "title": "C# official website?",
+        "title": "¿Sitio web oficial de C#?",
         "url": "https://learn.microsoft.com/en-us/dotnet/csharp//",
         "type": "article"
       },
       {
-        "title": "The Beginners Guide to C#",
+        "title": "La Guía para Principiantes de C#",
         "url": "https://www.w3schools.com/CS/index.php",
         "type": "article"
       },
       {
-        "title": "C# Tutorial",
+        "title": "Tutorial de C#",
         "url": "https://www.w3schools.com/cs/index.php",
         "type": "article"
       },
       {
-        "title": "Explore top posts about C#",
+        "title": "Explora las principales publicaciones sobre C#",
         "url": "https://app.daily.dev/tags/csharp?ref=roadmapsh",
         "type": "article"
       },
       {
-        "title": "C# Full Course - Learn C# 10 and .NET 6 in 7 hours",
+        "title": "Curso Completo de C# - Aprende C# 10 y .NET 6 en 7 horas",
         "url": "https://www.youtube.com/watch?v=q_F4PyW8GTg",
         "type": "video"
       }
@@ -58,20 +58,20 @@
   },
   "3GGvuxdfuDwLpNX_gtjCK": {
     "title": ".NET",
-    "description": ".NET (pronounced \"dot net\") is a software framework developed by Microsoft that can be used to create a wide range of applications, including Windows desktop and web applications, mobile apps, and gaming. The .NET Framework provides a large library of pre-built functionality, including collections, file input/output, and networking, that can be used by .NET applications. It also includes a Common Language Runtime (CLR) which manages the execution of code, providing features such as memory management, security, and exception handling.\n\nFor more information, visit the following link:",
+    "description": ".NET (pronunciado \"dot net\") es un marco de software desarrollado por Microsoft que se puede utilizar para crear una amplia gama de aplicaciones, incluidas aplicaciones de escritorio y web de Windows, aplicaciones móviles y juegos. .NET Framework proporciona una gran biblioteca de funcionalidades preconstruidas, que incluyen colecciones, entrada/salida de archivos y redes, que pueden ser utilizadas por aplicaciones .NET. También incluye un Common Language Runtime (CLR) que gestiona la ejecución del código, proporcionando características como la gestión de memoria, la seguridad y el manejo de excepciones.\n\nPara obtener más información, visite el siguiente enlace:",
     "links": [
       {
-        "title": "What is .NET?",
+        "title": "¿Qué es .NET?",
         "url": "https://dotnet.microsoft.com/en-us/learn/dotnet/what-is-dotnet",
         "type": "article"
       },
       {
-        "title": "An Overview of .NET",
+        "title": "Una Visión General de .NET",
         "url": "https://auth0.com/blog/what-is-dotnet-platform-overview/",
         "type": "article"
       },
       {
-        "title": "Explore top posts about .NET",
+        "title": "Explora las principales publicaciones sobre .NET",
         "url": "https://app.daily.dev/tags/.net?ref=roadmapsh",
         "type": "article"
       }

--- a/public/roadmap-content/blockchain.json
+++ b/public/roadmap-content/blockchain.json
@@ -1,102 +1,102 @@
 {
   "MvpHHpbS-EksUfuOKILOq": {
-    "title": "Basic Blockchain Knowledge",
-    "description": "A blockchain is a decentralized, distributed, and oftentimes public, digital ledger consisting of records called blocks that is used to record transactions across many computers so that any involved block cannot be altered retroactively, without the alteration of all subsequent blocks.\n\nVisit the following resources to learn more:",
+    "title": "Conocimientos Básicos de Blockchain",
+    "description": "Una blockchain es un libro de contabilidad digital descentralizado, distribuido y, a menudo, público, que consta de registros llamados bloques que se utiliza para registrar transacciones en muchas computadoras de modo que cualquier bloque involucrado no pueda modificarse retroactivamente, sin la alteración de todos los bloques posteriores.\n\nVisita los siguientes recursos para obtener más información:",
     "links": [
       {
-        "title": "Introduction to Blockchain",
+        "title": "Introducción a Blockchain",
         "url": "https://chain.link/education-hub/blockchain",
         "type": "article"
       },
       {
-        "title": "Blockchain Explained",
+        "title": "Blockchain Explicado",
         "url": "https://www.investopedia.com/terms/b/blockchain.asp",
         "type": "article"
       },
       {
-        "title": "An Elementary and Slightly Distilled Introduction to Blockchain",
+        "title": "Una Introducción Elemental y Ligeramente Destilada a Blockchain",
         "url": "https://markpetherbridge.co.uk/blog/an-elementary-and-slightly-distilled-introduction-to-blockchain/",
         "type": "article"
       },
       {
-        "title": "Explore top posts about Blockchain",
+        "title": "Explora las principales publicaciones sobre Blockchain",
         "url": "https://app.daily.dev/tags/blockchain?ref=roadmapsh",
         "type": "article"
       },
       {
-        "title": "How does a blockchain work?",
+        "title": "¿Cómo funciona una blockchain?",
         "url": "https://youtu.be/SSo_EIwHSd4",
         "type": "video"
       },
       {
-        "title": "What Is a Blockchain? | Blockchain Basics for Developers",
+        "title": "¿Qué es una Blockchain? | Conceptos Básicos de Blockchain para Desarrolladores",
         "url": "https://youtu.be/4ff9esY_4aU",
         "type": "video"
       }
     ]
   },
   "Atv-4Q7edtvfySs_XhgEq": {
-    "title": "Blockchain Structure",
-    "description": "The blockchain gets its name from its underlying structure. The blockchain is organized as a series of “blocks” that are “chained” together.\n\nUnderstanding blockchain security requires understanding how the blockchain is put together. This requires knowing what the blocks and chains of blockchain are and why they are designed the way that they are.\n\nVisit the following resources to learn more:",
+    "title": "Estructura de Blockchain",
+    "description": "La blockchain recibe su nombre de su estructura subyacente. La blockchain se organiza como una serie de “bloques” que están “encadenados” entre sí.\n\nComprender la seguridad de la blockchain requiere comprender cómo se arma la blockchain. Esto requiere saber qué son los bloques y las cadenas de la blockchain y por qué están diseñados de la manera en que lo están.\n\nVisita los siguientes recursos para obtener más información:",
     "links": [
       {
-        "title": "Blockchain Basics | Coursera",
+        "title": "Conceptos Básicos de Blockchain | Coursera",
         "url": "https://www.coursera.org/lecture/blockchain-basics/blockchain-structure-5rj9Z",
         "type": "course"
       },
       {
-        "title": "Blockchain Architecture Basics: Components, Structure, Benefits & Creation",
+        "title": "Conceptos Básicos de la Arquitectura Blockchain: Componentes, Estructura, Beneficios y Creación",
         "url": "https://mlsdev.com/blog/156-how-to-build-your-own-blockchain-architecture",
         "type": "article"
       },
       {
-        "title": "Blockchain Architecture 101: Components, Structure, and Benefits",
+        "title": "Arquitectura Blockchain 101: Componentes, Estructura y Beneficios",
         "url": "https://komodoplatform.com/en/academy/blockchain-architecture-101/",
         "type": "article"
       },
       {
-        "title": "Blockchain structure",
+        "title": "Estructura de Blockchain",
         "url": "https://resources.infosecinstitute.com/topic/blockchain-structure/",
         "type": "article"
       },
       {
-        "title": "Explore top posts about Blockchain",
+        "title": "Explora las principales publicaciones sobre Blockchain",
         "url": "https://app.daily.dev/tags/blockchain?ref=roadmapsh",
         "type": "article"
       }
     ]
   },
   "9z0Fqn1qqN8eo6s7_kwcb": {
-    "title": "Basic Blockchain Operations",
-    "description": "Operations in a decentralized networks are the responsibility of the peer participants and their respective computational nodes. These are specific for each type of blockchain.\n\nVisit the following resources to learn more:",
+    "title": "Operaciones Básicas de Blockchain",
+    "description": "Las operaciones en redes descentralizadas son responsabilidad de los participantes pares y sus respectivos nodos computacionales. Estas son específicas para cada tipo de blockchain.\n\nVisita los siguientes recursos para obtener más información:",
     "links": [
       {
-        "title": "Blockchain Basics | Coursera",
+        "title": "Conceptos Básicos de Blockchain | Coursera",
         "url": "https://www.coursera.org/lecture/blockchain-basics/basic-operations-OxILB",
         "type": "course"
       },
       {
-        "title": "Blockchain Basics: Structure, Operations, and the Bitcoin Blockchain",
+        "title": "Conceptos Básicos de Blockchain: Estructura, Operaciones y la Blockchain de Bitcoin",
         "url": "https://www.mlq.ai/blockchain-basics/",
         "type": "article"
       },
       {
-        "title": "Bitcoin Blockchain Transactions",
+        "title": "Transacciones de la Blockchain de Bitcoin",
         "url": "https://developer.bitcoin.org/reference/transactions.html",
         "type": "article"
       },
       {
-        "title": "Ethereum Blockchain Transactions",
+        "title": "Transacciones de la Blockchain de Ethereum",
         "url": "https://ethereum.org/en/developers/docs/transactions/",
         "type": "article"
       },
       {
-        "title": "Explore top posts about Blockchain",
+        "title": "Explora las principales publicaciones sobre Blockchain",
         "url": "https://app.daily.dev/tags/blockchain?ref=roadmapsh",
         "type": "article"
       },
       {
-        "title": "How Bitcoin Blockchain Actually",
+        "title": "Cómo Funciona Realmente la Blockchain de Bitcoin",
         "url": "https://www.youtube.com/watch?v=bBC-nXj3Ng4",
         "type": "video"
       }


### PR DESCRIPTION
This commit includes the Spanish translation for the following roadmap content files:

- public/roadmap-content/ai-agents.json
- public/roadmap-content/ai-data-scientist.json
- public/roadmap-content/ai-engineer.json
- public/roadmap-content/ai-red-teaming.json
- public/roadmap-content/android.json
- public/roadmap-content/angular.json
- public/roadmap-content/api-design.json
- public/roadmap-content/aspnet-core.json
- public/roadmap-content/backend.json
- public/roadmap-content/blockchain.json
- public/roadmap-content/cloudflare.json
- public/roadmap-content/computer-science.json

For each file, the 'title' and 'description' fields of main entries, and the 'title' field within the 'links' array, have been translated to Spanish. This is part of a larger effort to translate the entire program content to Spanish.